### PR TITLE
Use persistent self-hosted cache for verify builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve persistent verify builder name
+        id: verify_builder
+        run: |
+          set -euo pipefail
+          echo "name=odoo-docker-verify-chris-testing-${{ matrix.suffix }}" >> "${GITHUB_OUTPUT}"
+
       - id: setup_buildx_verify
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
+          name: ${{ steps.verify_builder.outputs.name }}
+          cleanup: false
+          keep-state: true
 
       - name: Validate odoo-bin wrapper behavior
         run: scripts/test-odoo-bin-wrapper.sh
@@ -95,8 +104,6 @@ jobs:
           load: true
           platforms: linux/amd64
           tags: odoo-docker:verify-${{ matrix.suffix }}
-          cache-from: type=gha,scope=odoo-docker-verify-${{ matrix.target }}-amd64
-          cache-to: type=gha,mode=max,scope=odoo-docker-verify-${{ matrix.target }}-amd64,ignore-error=true
           provenance: false
           sbom: false
           build-args: |
@@ -115,6 +122,7 @@ jobs:
           target: ${{ matrix.target }}
           pull: true
           load: true
+          no-cache: true
           platforms: linux/amd64
           tags: odoo-docker:verify-${{ matrix.suffix }}
           provenance: false
@@ -135,6 +143,17 @@ jobs:
       - name: Validate downstream helper contract
         if: matrix.target == 'runtime'
         run: scripts/test-downstream-helpers.sh odoo-docker:verify-runtime
+
+      - name: Prune stale persistent verify builder cache
+        if: always()
+        run: |
+          set -euo pipefail
+          docker buildx prune \
+            --builder "${{ steps.setup_buildx_verify.outputs.name }}" \
+            --force \
+            --filter 'until=168h' \
+            --max-used-space 20000000000 \
+            || true
 
   publish:
     runs-on: [self-hosted, linux, x64, chris-testing-publish-cache]


### PR DESCRIPTION
Closes #13

## Summary
- Replaces GHA cache import/export in verify image builds with persistent per-target Buildx builders on chris-testing.
- Keeps release publish registry-cache behavior unchanged.
- Uses a no-cache retry only after a cached verify build fails.
- Prunes stale verify builder cache after each run with an age and size cap.

## Verification
- `actionlint .github/workflows/build.yml`
- `git diff --check`
- JetBrains inspection: 0 problems shown; IDE snapshot reported `capture_incomplete`.

## Timing Notes
This is intended to be measured against PR Actions. The first run may warm the new persistent builder; a rerun on the same branch should show the useful cache behavior.
