### PR TITLE
Add runner health workflow permissions

### DIFF
--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "17 6 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   health:
     # Health checks should not consume the build lane that verify jobs need.


### PR DESCRIPTION
## Summary
- Add explicit `contents: read` permissions to the Runner Health workflow.
- Addresses the existing CodeQL `actions/missing-workflow-permissions` alert tracked in #26.

Refs #26

## Validation
- `actionlint .github/workflows/runner-health.yml`
- `git diff --check`

## Notes
- `yamllint --no-warnings .github/workflows/runner-health.yml` still reports pre-existing line-length errors in the workflow shell block; this PR does not add or modify those lines.