### PR TITLE
Exclude Code artifacts from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,12 @@
 .git
+.code
 .github
 *.md
 .DS_Store
 .idea
 tmp
 *.log
+*.override.*
 
 # Local secrets and credentials
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,19 @@ tmp/
 *.log
 .code/
 *.override.*
+
+# Local secrets and credentials
+.env
+.env.*
+!.env.example
+!.env.sample
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+.aws
+.npmrc
+.pypirc
+id_rsa
+id_ed25519


### PR DESCRIPTION
## Summary
- Add `.code` to `.dockerignore` so local Code agent logs and artifacts are excluded from Docker build contexts.
- Add `*.override.*` to `.dockerignore` to match the existing local override ignore rule.
- Align `.gitignore` with the existing `.dockerignore` local secret and credential patterns.

Refs #23

## Validation
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `git ls-files -ci --exclude-standard`

## Notes
- This is a focused cleanup slice for #23 and does not change image behavior or close the broader hygiene issue.