### PR TITLE
Document database smoke validation gate

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -14,6 +14,7 @@
     "smoke": {
       "runtime": "bash scripts/smoke-runtime.sh <image-reference>",
       "devtools": "bash scripts/smoke-devtools.sh <image-reference>",
+      "smokeDbInit": "bash scripts/smoke-db-init.sh <image-reference>",
       "downstreamHelpers": "bash scripts/test-downstream-helpers.sh <image-reference>",
       "odooBinWrapper": "bash scripts/test-odoo-bin-wrapper.sh"
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ Keep it short; defer deeper detail to the README and scripts.
 - Before release-oriented changes, run JetBrains inspections with the PyCharm
   inspection tool on changed scope and then whole-project scope.
 - Treat local image validation as part of the gate: build the affected target,
-  run the matching smoke script, and run `scripts/test-downstream-helpers.sh`
+  run the matching smoke script, run `scripts/smoke-db-init.sh` for runtime
+  database initialization coverage, and run `scripts/test-downstream-helpers.sh`
   for runtime changes that affect downstream behavior.
 - If a change affects downstream image semantics, verify with a real local
   build instead of reasoning from the Dockerfile alone.


### PR DESCRIPTION
## Summary
- Add `scripts/smoke-db-init.sh` to the repo workflow metadata smoke validation commands.
- Update AGENTS release-gate wording so runtime database initialization coverage is visible alongside image smoke and downstream helper checks.

Refs #23

## Validation
- `jq empty .github/github-repo-workflow.json`
- `actionlint .github/workflows/*.yml`
- `git diff --check`

## Notes
- Documentation and workflow metadata only; no image behavior changes.