### PR TITLE
Use Playwright-managed Chromium for devtools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -189,29 +189,45 @@ USER ubuntu
 
 FROM runtime AS runtime-devtools
 USER root
-ARG UBUNTU_CODENAME=noble
+ARG PLAYWRIGHT_VERSION=1.59.1
 
 RUN chmod +x /usr/local/bin/configure-dev-addon-paths.sh \
     && /usr/local/bin/configure-dev-addon-paths.sh
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/root/.npm,sharing=locked \
     apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
-    && mkdir -p /usr/share/keyrings \
-    && curl -fsSL --retry 5 --retry-all-errors --connect-timeout 30 \
-      "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x82BB6851C64F6880" \
-      | gpg --dearmor -o /usr/share/keyrings/xtradeb-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/xtradeb-archive-keyring.gpg] https://ppa.launchpadcontent.net/xtradeb/apps/ubuntu ${UBUNTU_CODENAME} main" \
-      > /etc/apt/sources.list.d/xtradeb-apps.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends chromium fonts-liberation libu2f-udev \
-    && test -x /usr/bin/chromium \
-    && dpkg-query -W -f='${binary:Package} ${Version}\n' chromium \
-      | grep -E '^chromium [0-9]' \
-    && /usr/bin/chromium --version \
-    && rm -f /etc/apt/sources.list.d/xtradeb-apps.list \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      fonts-liberation \
+      libasound2t64 \
+      libatk-bridge2.0-0t64 \
+      libatk1.0-0t64 \
+      libatspi2.0-0t64 \
+      libcups2t64 \
+      libdbus-1-3 \
+      libgbm1 \
+      libglib2.0-0t64 \
+      libnspr4 \
+      libnss3 \
+      libpango-1.0-0 \
+      libu2f-udev \
+      libx11-6 \
+      libxcb1 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxext6 \
+      libxfixes3 \
+      libxkbcommon0 \
+      libxrandr2 \
+      npm \
+    && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --no-shell \
+    && chromium_path="$(find /ms-playwright -path '*/chrome-linux*/chrome' -type f | sort | head -n 1)" \
+    && test -x "${chromium_path}" \
+    && ln -sfn "${chromium_path}" /usr/local/bin/chromium-playwright \
+    && /usr/local/bin/chromium-playwright --version \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CHROME_BIN=/usr/bin/chromium
+ENV CHROME_BIN=/usr/local/bin/chromium-playwright
 USER ubuntu

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository provides a stable base runtime for downstream project images.
 ## Images
 
 - `runtime`: base Odoo runtime + PostgreSQL client + uv tooling
-- `runtime-devtools`: `runtime` plus Chromium test tooling
+- `runtime-devtools`: `runtime` plus Playwright-managed Chromium test tooling
 
 Both images default to the `ubuntu` user for compatibility with existing
 restore and SSH mount workflows.
@@ -26,6 +26,8 @@ restore and SSH mount workflows.
   - `/odoo`
   - `/opt/project/addons`
   - `/opt/extra_addons`
+- `runtime-devtools` exposes Playwright-managed Chromium through `CHROME_BIN`
+  at `/usr/local/bin/chromium-playwright`.
 
 ## CLI Contract
 

--- a/scripts/smoke-devtools.sh
+++ b/scripts/smoke-devtools.sh
@@ -7,7 +7,11 @@ docker run --rm --entrypoint /bin/bash "${image_reference}" -lc '
 set -euo pipefail
 binary="${CHROME_BIN:-/usr/bin/chromium}"
 if [[ ! -x "${binary}" ]]; then
-  if [[ -x /usr/bin/chromium-browser ]]; then
+  if [[ -x /usr/local/bin/chromium-playwright ]]; then
+    binary="/usr/local/bin/chromium-playwright"
+  elif [[ -x /usr/bin/chromium ]]; then
+    binary="/usr/bin/chromium"
+  elif [[ -x /usr/bin/chromium-browser ]]; then
     binary="/usr/bin/chromium-browser"
   else
     echo "Chromium binary not found" >&2


### PR DESCRIPTION
## Summary
- Replace the xtradeb Launchpad PPA Chromium install in `runtime-devtools` with pinned Playwright-managed Chromium.
- Set `CHROME_BIN` to `/usr/local/bin/chromium-playwright` and update the devtools smoke test fallback path.
- Document the Playwright-managed Chromium contract in README.

Refs #23

## Why
The xtradeb PPA endpoint has been timing out (`ppa.launchpadcontent.net:443`), leaving `main` red even for docs-only changes. Playwright provides multi-arch Chromium downloads with CDN fallbacks and avoids Ubuntu Snap-in-Docker issues.

## Local Validation
- `git diff --check`
- `shellcheck scripts/smoke-devtools.sh`
- `actionlint .github/workflows/*.yml`
- `jq empty .github/github-repo-workflow.json`
- `docker build -t odoo-docker:verify-devtools-playwright --target runtime-devtools .`
- `scripts/smoke-devtools.sh odoo-docker:verify-devtools-playwright`
- `docker build --platform linux/amd64 -t odoo-docker:verify-devtools-playwright-amd64 --target runtime-devtools .`
- `scripts/smoke-devtools.sh odoo-docker:verify-devtools-playwright-amd64`
- `docker run --rm --platform linux/amd64 --entrypoint /bin/bash odoo-docker:verify-devtools-playwright-amd64 -lc 'test -x "${CHROME_BIN}" && "${CHROME_BIN}" --version && readlink -f "${CHROME_BIN}"'`\n\n## Notes\n- Local arm64 image inspected at about 1.0 GB.\n- Playwright downloads Chromium plus its ffmpeg helper; only Chromium is exposed through `CHROME_BIN`.\n- The Chromium executable directory differs by architecture (`chrome-linux` on arm64, `chrome-linux64` on amd64), so the Dockerfile discovers either path.