### PR TITLE
Use github.json for workflow metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -21,7 +21,11 @@
     "inspection": {
       "tool": "jetbrains",
       "ide": "PyCharm",
-      "scopePreference": ["changed_files", "directory", "whole_project"]
+      "scopePreference": [
+        "changed_files",
+        "directory",
+        "whole_project"
+      ]
     },
     "docsRequiredWhen": [
       "behavior changes",
@@ -50,7 +54,6 @@
     "odoo-shared-addons",
     "launchplane"
   ],
-  "validatedThrough": ["odoo-enterprise-docker"],
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,
@@ -80,7 +83,6 @@
       "primary commands change",
       "important workflows change",
       "repo relationship changes",
-      "validated-through repos change",
       "cleanup policy changes",
       "ownership boundaries change",
       "Dockerfile changes",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Keep it short; defer deeper detail to the README and scripts.
 
 ## Workflow Metadata
 
-- Use [`.github/github-repo-workflow.json`](.github/github-repo-workflow.json)
+- Use [`.github/github.json`](.github/github.json)
   for primary commands, validation gates, workflow routing, and cleanup policy.
 
 ## Release Gate


### PR DESCRIPTION
## Summary
- rename repo workflow metadata from `.github/github-repo-workflow.json` to `.github/github.json`
- update local guidance/docs to point at the canonical metadata path
- drop retired `validatedThrough` metadata while preserving the rest of the workflow facts

## Validation
- `jq empty .github/github.json`
- confirmed `.github/github-repo-workflow.json` is removed
- confirmed repo docs no longer reference `.github/github-repo-workflow.json`
- confirmed `.github/github.json` has no `validatedThrough` / `validated-through` entries
- compared old and new JSON content, allowing only the retired `validatedThrough` field/trigger removal
- `git diff --check`
