### PR TITLE
Add Hadolint Dockerfile check

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -18,6 +18,9 @@
       "downstreamHelpers": "bash scripts/test-downstream-helpers.sh <image-reference>",
       "odooBinWrapper": "bash scripts/test-odoo-bin-wrapper.sh"
     },
+    "lint": {
+      "dockerfile": "docker run --rm -v \"$PWD:/work:ro\" -w /work hadolint/hadolint:v2.14.0 hadolint Dockerfile"
+    },
     "inspection": {
       "tool": "jetbrains",
       "ide": "PyCharm",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
     branches: [main]
     paths:
       - Dockerfile
+      - .hadolint.yaml
       - requirements-overrides.txt
       - scripts/**
       - .github/workflows/build.yml
@@ -20,6 +21,7 @@ on:
     branches: [main]
     paths:
       - Dockerfile
+      - .hadolint.yaml
       - requirements-overrides.txt
       - scripts/**
       - .github/workflows/build.yml
@@ -36,6 +38,22 @@ env:
   DOCKER_BUILD_RECORD_UPLOAD: false
 
 jobs:
+  dockerfile-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run Hadolint
+        run: |
+          docker run --rm \
+            -v "$PWD:/work:ro" \
+            -w /work \
+            hadolint/hadolint:v2.14.0 \
+            hadolint Dockerfile
+
   resolve_source:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,8 @@
+ignored:
+  # Odoo runtime images intentionally refresh Ubuntu packages during image
+  # builds and rely on Trivy to block high/critical fixed vulnerabilities.
+  - DL3008
+
+  # The wkhtmltox stage uses alpine/curl's shell and a simple checksum pipe;
+  # switching shells there would add noise without changing runtime behavior.
+  - DL4006

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,14 @@ ARG ODOO_SOURCE_REV
 WORKDIR /source
 RUN set -eux; \
     git init odoo; \
-    cd odoo; \
-    git remote add origin "${ODOO_SOURCE_REPOSITORY}"; \
+    git -C odoo remote add origin "${ODOO_SOURCE_REPOSITORY}"; \
     if [ -n "${ODOO_SOURCE_REV:-}" ]; then \
-      git fetch --depth 1 origin "${ODOO_SOURCE_REV}"; \
+      git -C odoo fetch --depth 1 origin "${ODOO_SOURCE_REV}"; \
     else \
-      git fetch --depth 1 origin "refs/heads/${ODOO_SOURCE_REF}"; \
+      git -C odoo fetch --depth 1 origin "refs/heads/${ODOO_SOURCE_REF}"; \
     fi; \
-    git checkout --detach FETCH_HEAD; \
-    rm -rf .git
+    git -C odoo checkout --detach FETCH_HEAD; \
+    rm -rf odoo/.git
 
 FROM --platform=$BUILDPLATFORM alpine/curl:8.20.0 AS wkhtmltox
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
- add a tuned Hadolint config for the Dockerfile baseline
- add a lightweight dockerfile-lint job to the image workflow
- remove the actionable DL3003 warning by avoiding cd in the source-fetch stage
- record the Hadolint command in repo metadata

## Validation
- docker run --rm -v "/Users/cbusillo/Developer/odoo-docker:/work:ro" -w /work hadolint/hadolint:v2.14.0 hadolint Dockerfile
- jq empty .github/github.json
- actionlint -config-file .github/actionlint.yaml .github/workflows/build.yml