### PR TITLE
Fix lxml HTML cleaner vulnerability

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -16,7 +16,8 @@
       "devtools": "bash scripts/smoke-devtools.sh <image-reference>",
       "smokeDbInit": "bash scripts/smoke-db-init.sh <image-reference>",
       "downstreamHelpers": "bash scripts/test-downstream-helpers.sh <image-reference>",
-      "odooBinWrapper": "bash scripts/test-odoo-bin-wrapper.sh"
+      "odooBinWrapper": "bash scripts/test-odoo-bin-wrapper.sh",
+      "requirementsOverrides": "bash scripts/test-check-requirements-overrides.sh"
     },
     "lint": {
       "dockerfile": "docker run --rm -v \"$PWD:/work:ro\" -w /work hadolint/hadolint:v2.14.0 hadolint Dockerfile"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
           ODOO_SOURCE_REV: ${{ needs.resolve_source.outputs.odoo_source_rev }}
         run: |
           set -euo pipefail
+          bash scripts/test-check-requirements-overrides.sh
           curl -fsSL \
             "https://raw.githubusercontent.com/odoo/odoo/${ODOO_SOURCE_REV}/requirements.txt" \
             -o "${RUNNER_TEMP}/odoo-requirements.txt"

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ docker build \
 
 ## Validation Commands
 
+- `bash scripts/test-check-requirements-overrides.sh` checks exact pins,
+  explicitly allowed unpinned requirements, non-exact constraints, and removed
+  requirements for the override freshness gate.
 - `scripts/test-odoo-bin-wrapper.sh` checks wrapper argument handling without a
   container build.
 - `scripts/smoke-runtime.sh <image-reference>` checks the runtime image helper
@@ -181,3 +184,9 @@ docker build \
 - Do not add credentials or access tokens in this repo.
 - Proprietary addons should be fetched by downstream builds using BuildKit
   secrets via `odoo-fetch-addons.sh`.
+- `requirements-overrides.txt` carries minimum secure Python compatibility
+  pins when upstream Odoo requirements cannot yet resolve a fixed transitive
+  release. Keep those pins narrow and let
+  `scripts/check-requirements-overrides.py` reject removed upstream
+  requirements, unexpected unpinned or ranged requirements, and upstream exact
+  pins that make an override removable.

--- a/requirements-overrides.txt
+++ b/requirements-overrides.txt
@@ -4,7 +4,8 @@
 # catches up so this file can be removed instead of silently downgrading packages.
 cbor2==5.9.0
 cryptography==48.0.1
-lxml==6.1.0
+lxml==6.1.1  # Required by lxml-html-clean>=0.4.5 for CVE-2026-49825.
+lxml-html-clean==0.4.5
 Pillow==12.2.0
 pyopenssl==26.2.0
 urllib3==2.7.0

--- a/scripts/check-requirements-overrides.py
+++ b/scripts/check-requirements-overrides.py
@@ -12,13 +12,20 @@ from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 
-def active_exact_pins(requirements_path: Path, python_version: str) -> dict[str, Version]:
+UNPINNED_UPSTREAM_OVERRIDE_ALLOWLIST = frozenset({"lxml-html-clean"})
+
+
+def active_requirements(
+    requirements_path: Path, python_version: str
+) -> dict[str, Requirement]:
     environment = {key: str(value) for key, value in default_environment().items()}
     environment["python_version"] = python_version
     environment["python_full_version"] = f"{python_version}.0"
 
-    pins: dict[str, Version] = {}
-    for line_number, raw_line in enumerate(requirements_path.read_text(encoding="utf-8").splitlines(), 1):
+    requirements: dict[str, Requirement] = {}
+    for line_number, raw_line in enumerate(
+        requirements_path.read_text(encoding="utf-8").splitlines(), 1
+    ):
         line = raw_line.split("#", 1)[0].strip()
         if not line or line.startswith("-"):
             continue
@@ -26,21 +33,25 @@ def active_exact_pins(requirements_path: Path, python_version: str) -> dict[str,
         try:
             requirement = Requirement(line)
         except InvalidRequirement as exc:
-            raise SystemExit(f"{requirements_path}:{line_number}: invalid requirement: {raw_line}\n{exc}") from exc
+            raise SystemExit(
+                f"{requirements_path}:{line_number}: invalid requirement: {raw_line}\n{exc}"
+            ) from exc
 
-        if requirement.marker is not None and not requirement.marker.evaluate(environment):
+        if requirement.marker is not None and not requirement.marker.evaluate(
+            environment
+        ):
             continue
 
-        exact_versions = [Version(specifier.version) for specifier in requirement.specifier if specifier.operator == "=="]
-        if exact_versions:
-            pins[canonicalize_name(requirement.name)] = exact_versions[-1]
+        requirements[canonicalize_name(requirement.name)] = requirement
 
-    return pins
+    return requirements
 
 
 def override_pins(overrides_path: Path) -> dict[str, Version]:
     pins: dict[str, Version] = {}
-    for line_number, raw_line in enumerate(overrides_path.read_text(encoding="utf-8").splitlines(), 1):
+    for line_number, raw_line in enumerate(
+        overrides_path.read_text(encoding="utf-8").splitlines(), 1
+    ):
         line = raw_line.split("#", 1)[0].strip()
         if not line:
             continue
@@ -48,11 +59,19 @@ def override_pins(overrides_path: Path) -> dict[str, Version]:
         try:
             requirement = Requirement(line)
         except InvalidRequirement as exc:
-            raise SystemExit(f"{overrides_path}:{line_number}: invalid requirement: {raw_line}\n{exc}") from exc
+            raise SystemExit(
+                f"{overrides_path}:{line_number}: invalid requirement: {raw_line}\n{exc}"
+            ) from exc
 
-        exact_versions = [Version(specifier.version) for specifier in requirement.specifier if specifier.operator == "=="]
+        exact_versions = [
+            Version(specifier.version)
+            for specifier in requirement.specifier
+            if specifier.operator == "=="
+        ]
         if len(exact_versions) != 1:
-            raise SystemExit(f"{overrides_path}:{line_number}: overrides must use one exact == pin: {raw_line}")
+            raise SystemExit(
+                f"{overrides_path}:{line_number}: overrides must use one exact == pin: {raw_line}"
+            )
 
         pins[canonicalize_name(requirement.name)] = exact_versions[0]
 
@@ -66,20 +85,41 @@ def main() -> int:
     parser.add_argument("--python-version", required=True)
     args = parser.parse_args()
 
-    upstream_pins = active_exact_pins(args.requirements, args.python_version)
+    upstream_requirements = active_requirements(args.requirements, args.python_version)
     local_overrides = override_pins(args.overrides)
 
     failures: list[str] = []
     for name, override_version in sorted(local_overrides.items()):
-        upstream_version = upstream_pins.get(name)
-        if upstream_version is None:
-            failures.append(f"{name}: no active upstream pin for Python {args.python_version}")
-            continue
-        if upstream_version >= override_version:
+        upstream_requirement = upstream_requirements.get(name)
+        if upstream_requirement is None:
             failures.append(
-                f"{name}: upstream pins {upstream_version}, override pins {override_version}; "
-                "remove or raise the override"
+                f"{name}: no active upstream requirement for Python {args.python_version}"
             )
+            continue
+        specifiers = list(upstream_requirement.specifier)
+        if not specifiers:
+            if name not in UNPINNED_UPSTREAM_OVERRIDE_ALLOWLIST:
+                failures.append(
+                    f"{name}: upstream requirement is unpinned; exact override requires review"
+                )
+            continue
+        exact_versions = [
+            Version(specifier.version)
+            for specifier in specifiers
+            if specifier.operator == "==" and "*" not in specifier.version
+        ]
+        if len(specifiers) == 1 and len(exact_versions) == 1:
+            upstream_version = exact_versions[0]
+            if upstream_version >= override_version:
+                failures.append(
+                    f"{name}: upstream pins {upstream_version}, override pins {override_version}; "
+                    "remove or raise the override"
+                )
+            continue
+        failures.append(
+            f"{name}: upstream uses non-exact constraint "
+            f"{upstream_requirement.specifier}; exact override requires review"
+        )
 
     if failures:
         print("Stale requirements overrides detected:")
@@ -87,7 +127,7 @@ def main() -> int:
             print(f"- {failure}")
         return 1
 
-    print(f"requirements overrides are still ahead of upstream for Python {args.python_version}")
+    print(f"requirements overrides remain valid for Python {args.python_version}")
     return 0
 
 

--- a/scripts/test-check-requirements-overrides.sh
+++ b/scripts/test-check-requirements-overrides.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'find "${test_root}" -depth -delete' EXIT
+
+requirements_file="${test_root}/requirements.txt"
+overrides_file="${test_root}/overrides.txt"
+output_file="${test_root}/output.txt"
+
+run_check() {
+	python3 "${repo_root}/scripts/check-requirements-overrides.py" \
+		--requirements "${requirements_file}" \
+		--overrides "${overrides_file}" \
+		--python-version 3.13
+}
+
+printf 'lxml-html-clean\n' >"${requirements_file}"
+printf 'lxml-html-clean==0.4.5\n' >"${overrides_file}"
+run_check >"${output_file}"
+grep -Fq 'requirements overrides remain valid' "${output_file}"
+
+printf 'demo\n' >"${requirements_file}"
+printf 'demo==1.2.0\n' >"${overrides_file}"
+if run_check >"${output_file}"; then
+	echo 'Expected an unregistered unpinned requirement to require review.' >&2
+	exit 1
+fi
+grep -Fq 'upstream requirement is unpinned; exact override requires review' "${output_file}"
+
+printf 'demo==1.1.0 ; python_version >= "3.13"\n' >"${requirements_file}"
+run_check >"${output_file}"
+grep -Fq 'requirements overrides remain valid' "${output_file}"
+
+printf 'demo==1.2.0\n' >"${requirements_file}"
+if run_check >"${output_file}"; then
+	echo 'Expected an exact upstream pin to make the override stale.' >&2
+	exit 1
+fi
+grep -Fq 'upstream pins 1.2.0, override pins 1.2.0' "${output_file}"
+
+printf 'demo==1.3.0\n' >"${requirements_file}"
+if run_check >"${output_file}"; then
+	echo 'Expected a higher exact upstream pin to make the override stale.' >&2
+	exit 1
+fi
+grep -Fq 'upstream pins 1.3.0, override pins 1.2.0' "${output_file}"
+
+printf 'demo>=1.3.0\n' >"${requirements_file}"
+if run_check >"${output_file}"; then
+	echo 'Expected a non-exact upstream constraint to require review.' >&2
+	exit 1
+fi
+grep -Fq 'upstream uses non-exact constraint >=1.3.0' "${output_file}"
+
+printf 'demo==1.1.0,>=1.0.0\n' >"${requirements_file}"
+if run_check >"${output_file}"; then
+	echo 'Expected mixed exact and range constraints to require review.' >&2
+	exit 1
+fi
+grep -Fq 'upstream uses non-exact constraint' "${output_file}"
+
+printf 'other==1.0.0\n' >"${requirements_file}"
+if run_check >"${output_file}"; then
+	echo 'Expected a missing upstream requirement to reject the override.' >&2
+	exit 1
+fi
+grep -Fq 'no active upstream requirement for Python 3.13' "${output_file}"
+
+echo 'requirements override checks passed'


### PR DESCRIPTION
## Summary
- pin `lxml-html-clean` 0.4.5 and compatible `lxml` 6.1.1 to remediate CVE-2026-49825
- allow the deliberately unpinned upstream requirement through a narrow exception while failing closed on unexpected unpinned, ranged, mixed, removed, or stale exact requirements
- add regression coverage and wire it into CI and repository quality-gate metadata
- document the secure override lifecycle

## Validation
- runtime and devtools image builds — passed
- runtime, devtools, database-init, and downstream-helper smoke tests — passed
- Trivy high/critical scans for both images — 0 findings
- live Odoo 19 requirements freshness check — passed
- Ruff, shellcheck, shfmt, actionlint, and diff checks — passed
- JetBrains changed-files inspection — green
- two independent review passes — no remaining blockers

Closes #56
Parent workstream: cbusillo/launchplane#1629