### PR TITLE
Require image verification before merge

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -52,13 +52,7 @@
     "Dependency Graph",
     "Dependabot Updates"
   ],
-  "requiredStatusChecks": [
-    "dockerfile-lint",
-    "resolve_source",
-    "check_overrides",
-    "verify (runtime, runtime, scripts/smoke-runtime.sh)",
-    "verify (runtime-devtools, devtools, scripts/smoke-devtools.sh)"
-  ],
+  "requiredStatusChecks": ["image-verification"],
   "codeScanningMergeProtection": {
     "ruleset": "Require code scanning results",
     "tool": "CodeQL",

--- a/.github/github.json
+++ b/.github/github.json
@@ -52,7 +52,13 @@
     "Dependency Graph",
     "Dependabot Updates"
   ],
-  "requiredStatusChecks": [],
+  "requiredStatusChecks": [
+    "dockerfile-lint",
+    "resolve_source",
+    "check_overrides",
+    "verify (runtime, runtime, scripts/smoke-runtime.sh)",
+    "verify (runtime-devtools, devtools, scripts/smoke-devtools.sh)"
+  ],
   "codeScanningMergeProtection": {
     "ruleset": "Require code scanning results",
     "tool": "CodeQL",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,6 @@ on:
         type: boolean
   pull_request:
     branches: [main]
-    paths:
-      - Dockerfile
-      - .hadolint.yaml
-      - requirements-overrides.txt
-      - scripts/**
-      - .github/workflows/build.yml
-      - README.md
   push:
     branches: [main]
     paths:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,9 @@ jobs:
             --python-version 3.13
 
   verify:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, x64, chris-testing-build]
     timeout-minutes: 60
     needs: [resolve_source, check_overrides]
@@ -211,6 +214,43 @@ jobs:
             --filter 'until=168h' \
             --keep-storage 60000000000 \
             || true
+
+  image_verification:
+    name: image-verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [dockerfile-lint, resolve_source, check_overrides, verify]
+    if: always() && github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - name: Require successful image verification
+        env:
+          BASE_REPOSITORY: ${{ github.repository }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          DOCKERFILE_LINT_RESULT: ${{ needs.dockerfile-lint.result }}
+          RESOLVE_SOURCE_RESULT: ${{ needs.resolve_source.result }}
+          CHECK_OVERRIDES_RESULT: ${{ needs.check_overrides.result }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+        run: |
+          set -euo pipefail
+          if [ "${HEAD_REPOSITORY}" != "${BASE_REPOSITORY}" ]; then
+            echo "Fork pull requests cannot run trusted self-hosted image verification." >&2
+            echo "Recreate the change on a branch in ${BASE_REPOSITORY} before merging." >&2
+            exit 1
+          fi
+
+          for result in \
+            "${DOCKERFILE_LINT_RESULT}" \
+            "${RESOLVE_SOURCE_RESULT}" \
+            "${CHECK_OVERRIDES_RESULT}" \
+            "${VERIFY_RESULT}"
+          do
+            if [ "${result}" != "success" ]; then
+              echo "Required image verification job concluded with: ${result}" >&2
+              exit 1
+            fi
+          done
 
   publish:
     runs-on: [self-hosted, linux, x64, chris-testing-publish-cache]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,12 @@ those image-owned defaults present.
 - Publish only happens after smoke checks pass.
 - `schedule` (weekly) publishes `nightly-*` tags and immutable `sha-*` tags.
 - `push` to `main` publishes stable `19.0-*` tags and immutable `sha-*` tags.
-- `pull_request` runs verify-only (no image publishing).
+- `pull_request` runs verify-only (no image publishing) and reports one stable
+  `image-verification` merge gate after lint, source resolution, override
+  validation, both image builds, smoke tests, and vulnerability scans pass.
+- Fork pull requests fail closed before using trusted self-hosted runners. A
+  maintainer must recreate an accepted fork change on a branch in this
+  repository before it can pass the image-verification merge gate.
 
 This lets us keep a weekly canary stream while protecting stable tags behind the
 same verification gate.


### PR DESCRIPTION
## Summary
- record the five GitHub Actions checks now required by `main` branch protection
- run the verification workflow on every pull request so required checks are never missing on metadata-only changes
- cover Dockerfile lint, source resolution, override validation, and both runtime image verification jobs
- keep repository metadata aligned with the live protection state

## Validation
- `.github/github.json` parses successfully
- `git diff --check` passes
- metadata check names exactly match live branch protection
- Docker actionlint passes
- IDE inspection not run: workflow/configuration-only change, no application code paths affected

Related to cbusillo/launchplane#1632