### PR TITLE
Override PyPDF security fixes

### DIFF
--- a/requirements-overrides.txt
+++ b/requirements-overrides.txt
@@ -8,6 +8,7 @@ lxml==6.1.1  # Required by lxml-html-clean>=0.4.5 for CVE-2026-49825.
 lxml-html-clean==0.4.5
 Pillow==12.3.0
 pyopenssl==26.2.0
+pypdf==6.14.2  # Fixes CVE-2026-59935 and CVE-2026-59936.
 requests==2.34.2
 urllib3==2.7.0
 Werkzeug==3.1.6

--- a/scripts/test-check-requirements-overrides.sh
+++ b/scripts/test-check-requirements-overrides.sh
@@ -22,6 +22,11 @@ printf 'lxml-html-clean==0.4.5\n' >"${overrides_file}"
 run_check >"${output_file}"
 grep -Fq 'requirements overrides remain valid' "${output_file}"
 
+printf 'PyPDF==5.4.0 ; python_version >= "3.13"\n' >"${requirements_file}"
+printf 'pypdf==6.14.2\n' >"${overrides_file}"
+run_check >"${output_file}"
+grep -Fq 'requirements overrides remain valid' "${output_file}"
+
 printf 'demo\n' >"${requirements_file}"
 printf 'demo==1.2.0\n' >"${overrides_file}"
 if run_check >"${output_file}"; then


### PR DESCRIPTION
## Summary
- override upstream Odoo 19's Python 3.13 `PyPDF==5.4.0` pin with reviewed `pypdf==6.14.2`
- clear HIGH findings CVE-2026-59935 and CVE-2026-59936 in runtime and devtools images
- add override-freshness regression coverage for the case-normalized upstream pin

## Recovery Evidence
Enterprise image refresh run `30411722434` failed closed during both image scans because the inherited runtime contained `pypdf` 5.4.0. Publication did not run and stable enterprise tags did not move. This public base-image override is the documented owner boundary for that dependency.

## Validation
- `bash scripts/test-check-requirements-overrides.sh`
- `shfmt -d scripts/test-check-requirements-overrides.sh`
- `shellcheck scripts/test-check-requirements-overrides.sh`
- `git diff --check`
- JetBrains changed-files and whole-project inspections: clean, 0 findings
- local Docker daemon was unavailable; the required self-hosted `image-verification` PR gate remains the authoritative real build, smoke, database-init, downstream-helper, and vulnerability-scan evidence

Related to cbusillo/launchplane#1890