### PR TITLE
Remediate Odoo runtime image vulnerabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Keep it short; defer deeper detail to the README and scripts.
 - Preserve `/venv`, `/opt/project`, `/opt/project/addons`, and
   `/opt/extra_addons` as stable downstream layout guarantees. Preserve
   `/opt/launchplane/addons` as the image-owned runtime addon root.
+- Keep `pip` out of the runtime virtual environment. Use the image-owned `uv`
+  binary for base and downstream Python dependency installation.
 
 ## Workflow Metadata
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,7 +159,6 @@ RUN --mount=type=cache,target=/home/ubuntu/.cache/uv,uid=1000,gid=1000,sharing=l
     && chown -R ubuntu:ubuntu /home/ubuntu/.cache/uv \
     && su -s /bin/bash ubuntu -c "uv python install '${PYTHON_VERSION}'" \
     && su -s /bin/bash ubuntu -c "uv venv /venv --python '${PYTHON_VERSION}'" \
-    && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python --upgrade pip" \
     && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python -r /odoo/requirements.txt" \
     && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python -r /odoo/requirements-overrides.txt" \
     && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python rlpycairo" \

--- a/README.md
+++ b/README.md
@@ -240,3 +240,7 @@ docker build \
   `scripts/check-requirements-overrides.py` reject removed upstream
   requirements, unexpected unpinned or ranged requirements, and upstream exact
   pins that make an override removable.
+- The runtime virtual environment intentionally does not ship `pip`. Image
+  builds and downstream dependency synchronization use `uv`; restoring `pip`
+  would add unused vendored packages and expand the runtime vulnerability and
+  supply-chain surface.

--- a/requirements-overrides.txt
+++ b/requirements-overrides.txt
@@ -3,11 +3,11 @@
 # broad latest releases. scripts/check-requirements-overrides.py fails CI once upstream
 # Odoo catches up so entries can be removed instead of silently downgrading packages.
 cbor2==5.9.0
-cryptography==48.0.1
+cryptography==50.0.0  # Fixes CVE-2026-69247 and CVE-2026-69249.
 lxml==6.1.1  # Required by lxml-html-clean>=0.4.5 for CVE-2026-49825.
 lxml-html-clean==0.4.5
 Pillow==12.3.0
-pyopenssl==26.2.0
+pyopenssl==26.4.0  # Required for cryptography>=49 compatibility.
 pypdf==6.14.2  # Fixes CVE-2026-59935 and CVE-2026-59936.
 requests==2.34.2
 urllib3==2.7.0

--- a/scripts/smoke-runtime.sh
+++ b/scripts/smoke-runtime.sh
@@ -18,6 +18,9 @@ test -d /opt/launchplane/addons
 test -f /opt/launchplane/addons/launchplane_runtime_health/__manifest__.py
 test -f /volumes/config/_generated.conf
 /venv/bin/python -c "import sys; assert sys.version_info[:2] == (3, 13), sys.version"
+/venv/bin/python -c "import cryptography, OpenSSL"
+test ! -e /venv/bin/pip
+/venv/bin/python -c "import importlib.util; assert importlib.util.find_spec(\"pip\") is None"
 /odoo/odoo-bin --help >/dev/null
 /odoo/odoo-bin shell --help >/dev/null
 ODOO_SOURCE_BIN=/bin/true ODOO_WRAPPER_PYTHON=/bin/echo /odoo/odoo-bin --stop-after-init | grep -F -- "--load=base,web,launchplane_runtime_health" >/dev/null


### PR DESCRIPTION
## Summary
- update `cryptography` to 50.0.0 with the required `pyOpenSSL` 26.4.0 compatibility pair
- remove unnecessary `pip` from the runtime venv, eliminating its vendored vulnerable `msgpack` and `setuptools` copies
- assert crypto imports and pip absence in runtime smoke coverage
- document the downstream `uv`-only runtime installation contract

## Security posture
- no Trivy exceptions or ignore entries
- no severity narrowing or stale-override allowlist changes
- removes an unpinned runtime package fetch and reduces final-image attack surface

## Validation
- shfmt, shellcheck, requirements override tests, and hadolint passed
- real runtime and runtime-devtools image builds passed
- runtime, database-init, downstream-helper, devtools, and wrapper smoke suites passed
- in-build `uv pip check` passed
- Trivy 0.70.0 HIGH/CRITICAL fail-closed scans passed on both image variants
- JetBrains changed-files inspection green; whole-project capture was inconclusive because project analysis did not become ready, with no findings attributed to the patch
- Opus and Gemini final review: approve

## Downstream contract
The runtime venv intentionally no longer contains `pip`; downstream dependency installation must use the image-owned `uv` binary.

Fixes #76
Supersedes #72