### PR TITLE
Fix idna denial-of-service vulnerabilities

### DIFF
--- a/requirements-overrides.txt
+++ b/requirements-overrides.txt
@@ -4,6 +4,7 @@
 # Odoo catches up so entries can be removed instead of silently downgrading packages.
 cbor2==5.9.0
 cryptography==50.0.0  # Fixes CVE-2026-69247 and CVE-2026-69249.
+idna==3.18  # Fixes CVE-2024-3651 and CVE-2026-45409.
 lxml==6.1.1  # Required by lxml-html-clean>=0.4.5 for CVE-2026-49825.
 lxml-html-clean==0.4.5
 Pillow==12.3.0


### PR DESCRIPTION
## Summary

- override Odoo 19's base-owned `idna==3.6` with exact `idna==3.18`
- close the vulnerable ranges for CVE-2024-3651 and CVE-2026-45409
- preserve the existing exact-base and downstream dependency contracts

## Validation

- `bash scripts/test-check-requirements-overrides.sh`
- live Odoo 19 override validation at source `57ffa1abb6e1ed481b8bccc5db5534ea0ad2c6b5`
- native runtime and devtools image builds
- runtime, devtools, and database-initialization smokes
- downstream helper contract suite
- exact installed-version assertion for `idna==3.18`
- Trivy 0.70.0 HIGH/CRITICAL scans: clean for both images

## Notes

JetBrains changed-files inspection was attempted but remained inconclusive because the IDE could not open the isolated worktree. No source or workflow files changed; GitHub image verification remains the authoritative release gate.

Refs #78