### PR TITLE
Keep runtime Python installations pip-free

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,9 @@ Keep it short; defer deeper detail to the README and scripts.
 - Preserve `/venv`, `/opt/project`, `/opt/project/addons`, and
   `/opt/extra_addons` as stable downstream layout guarantees. Preserve
   `/opt/launchplane/addons` as the image-owned runtime addon root.
-- Keep `pip` out of the runtime virtual environment. Use the image-owned `uv`
-  binary for base and downstream Python dependency installation.
+- Keep `pip` and `ensurepip` out of the runtime Python installations, including
+  `/venv` and the uv-managed interpreter under `/opt/uv/python`. Use the
+  image-owned `uv` binary for base and downstream Python dependency installation.
 
 ## Workflow Metadata
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       openssh-client \
       pkg-config \
       python3 \
-      python3-venv \
       ripgrep \
       rsync \
       tini \
@@ -159,6 +158,23 @@ RUN --mount=type=cache,target=/home/ubuntu/.cache/uv,uid=1000,gid=1000,sharing=l
     && chown -R ubuntu:ubuntu /home/ubuntu/.cache/uv \
     && su -s /bin/bash ubuntu -c "uv python install '${PYTHON_VERSION}'" \
     && su -s /bin/bash ubuntu -c "uv venv /venv --python '${PYTHON_VERSION}'" \
+    && base_python="$(su -s /bin/bash ubuntu -c 'PYTHONDONTWRITEBYTECODE=1 /venv/bin/python -c "import sys; print(sys._base_executable)"')" \
+    && case "${base_python}" in /opt/uv/python/*) ;; *) echo "Unexpected base interpreter: ${base_python}" >&2; exit 1 ;; esac \
+    && base_site_packages="$(env -u VIRTUAL_ENV PYTHONDONTWRITEBYTECODE=1 "${base_python}" -c 'import sysconfig; print(sysconfig.get_path("purelib"))')" \
+    && base_scripts="$(env -u VIRTUAL_ENV PYTHONDONTWRITEBYTECODE=1 "${base_python}" -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" \
+    && base_stdlib="$(env -u VIRTUAL_ENV PYTHONDONTWRITEBYTECODE=1 "${base_python}" -c 'import sysconfig; print(sysconfig.get_path("stdlib"))')" \
+    && for managed_path in "${base_site_packages}" "${base_scripts}" "${base_stdlib}"; do \
+      case "${managed_path}" in /opt/uv/python/*) ;; *) echo "Unexpected managed Python path: ${managed_path}" >&2; exit 1 ;; esac; \
+      test -d "${managed_path}"; \
+    done \
+    && rm -rf \
+      "${base_site_packages}/pip" \
+      "${base_site_packages}"/pip-*.dist-info \
+      "${base_scripts}"/pip* \
+      "${base_stdlib}/ensurepip" \
+    && test -z "$(find "${base_site_packages}" -maxdepth 1 -name 'pip-*.dist-info' -print -quit)" \
+    && test -z "$(find "${base_scripts}" -maxdepth 1 -name 'pip*' -print -quit)" \
+    && env -u VIRTUAL_ENV PYTHONDONTWRITEBYTECODE=1 "${base_python}" -c 'import importlib.util; assert importlib.util.find_spec("pip") is None; assert importlib.util.find_spec("ensurepip") is None' \
     && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python -r /odoo/requirements.txt" \
     && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python -r /odoo/requirements-overrides.txt" \
     && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python rlpycairo" \

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ docker build \
   container build.
 - `scripts/smoke-runtime.sh <image-reference>` checks the runtime image helper
   contract and Odoo CLI availability.
-- `scripts/smoke-devtools.sh <image-reference>` checks the devtools image
-  browser tooling and addon path setup.
+- `scripts/smoke-devtools.sh <image-reference>` checks the runtime contract
+  before checking the devtools image browser tooling and addon path setup.
 - `scripts/smoke-db-init.sh <image-reference>` checks database-backed Odoo
   initialization.
 - `scripts/test-downstream-helpers.sh <image-reference>` checks downstream
@@ -240,7 +240,9 @@ docker build \
   `scripts/check-requirements-overrides.py` reject removed upstream
   requirements, unexpected unpinned or ranged requirements, and upstream exact
   pins that make an override removable.
-- The runtime virtual environment intentionally does not ship `pip`. Image
-  builds and downstream dependency synchronization use `uv`; restoring `pip`
-  would add unused vendored packages and expand the runtime vulnerability and
-  supply-chain surface.
+- Neither the runtime virtual environment nor its uv-managed base interpreter
+  under `/opt/uv/python` ships `pip` or `ensurepip`. Image builds and downstream
+  dependency synchronization use `uv`; restoring `pip` would add unused
+  vendored packages and expand the runtime vulnerability and supply-chain
+  surface. Standard-library virtual environment bootstrapping with bundled
+  `pip` is intentionally unavailable; use `uv venv` instead.

--- a/scripts/smoke-devtools.sh
+++ b/scripts/smoke-devtools.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 image_reference="${1:?Usage: scripts/smoke-devtools.sh <image-reference>}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"${script_dir}/smoke-runtime.sh" "${image_reference}"
 
 docker run --rm --entrypoint /bin/bash "${image_reference}" -lc '
 set -euo pipefail

--- a/scripts/smoke-runtime.sh
+++ b/scripts/smoke-runtime.sh
@@ -21,6 +21,21 @@ test -f /volumes/config/_generated.conf
 /venv/bin/python -c "import cryptography, OpenSSL"
 test ! -e /venv/bin/pip
 /venv/bin/python -c "import importlib.util; assert importlib.util.find_spec(\"pip\") is None"
+test ! -e /usr/share/python-wheels
+/usr/bin/python3 -c "import importlib.util; assert importlib.util.find_spec(\"pip\") is None; assert importlib.util.find_spec(\"ensurepip\") is None"
+base_python="$(/venv/bin/python -c "import sys; print(sys._base_executable)")"
+case "${base_python}" in /opt/uv/python/*) ;; *) echo "Unexpected base interpreter: ${base_python}" >&2; exit 1 ;; esac
+base_site_packages="$(env -u VIRTUAL_ENV "${base_python}" -c "import sysconfig; print(sysconfig.get_path(\"purelib\"))")"
+base_scripts="$(env -u VIRTUAL_ENV "${base_python}" -c "import sysconfig; print(sysconfig.get_path(\"scripts\"))")"
+base_stdlib="$(env -u VIRTUAL_ENV "${base_python}" -c "import sysconfig; print(sysconfig.get_path(\"stdlib\"))")"
+for managed_path in "${base_site_packages}" "${base_scripts}" "${base_stdlib}"; do
+  case "${managed_path}" in /opt/uv/python/*) ;; *) echo "Unexpected managed Python path: ${managed_path}" >&2; exit 1 ;; esac
+  test -d "${managed_path}"
+done
+test -z "$(find "${base_site_packages}" -maxdepth 1 -name "pip-*.dist-info" -print -quit)"
+test -z "$(find "${base_scripts}" -maxdepth 1 -name "pip*" -print -quit)"
+test ! -e "${base_stdlib}/ensurepip"
+env -u VIRTUAL_ENV "${base_python}" -c "import importlib.util; assert importlib.util.find_spec(\"pip\") is None; assert importlib.util.find_spec(\"ensurepip\") is None"
 /odoo/odoo-bin --help >/dev/null
 /odoo/odoo-bin shell --help >/dev/null
 ODOO_SOURCE_BIN=/bin/true ODOO_WRAPPER_PYTHON=/bin/echo /odoo/odoo-bin --stop-after-init | grep -F -- "--load=base,web,launchplane_runtime_health" >/dev/null


### PR DESCRIPTION
## Summary

- remove the redundant Ubuntu `python3-venv` package and its bundled package-manager payloads
- remove `pip`, its console scripts and metadata, and `ensurepip` from the uv-managed interpreter in the same build layer that installs Python
- fail closed when `/venv` does not resolve to the expected managed interpreter layout
- enforce the pip-free contract across distro Python, `/venv`, managed Python, runtime, and devtools smoke coverage
- document `uv` as the only supported Python environment and dependency installer

## Why

Dependabot PR #81 exposed two fixed HIGH findings from packages vendored inside the managed interpreter's bundled `pip`:

- `msgpack` 1.1.2 (`GHSA-6v7p-g79w-8964`)
- `setuptools` 70.3.0 (`CVE-2025-47273`)

Installing separate package overrides would not replace those vendored copies. The runtime does not need `pip`; base and downstream dependency operations use the image-owned `uv` binary.

## Validation

- native arm64 runtime and devtools image builds
- runtime smoke on both final targets
- devtools smoke
- database initialization smoke
- downstream helper contract suite
- Odoo wrapper and requirements-override tests
- hadolint, shellcheck, shfmt, and diff checks
- Trivy 0.70 HIGH/CRITICAL scans on runtime and devtools: zero findings
- PyCharm changed-files inspection: only three pre-existing `HttpUrlsUsage` warnings on HTTP source strings immediately rewritten to HTTPS
- PyCharm whole-project inspection: pre-existing broad and cross-repo findings; no findings introduced in the changed shell/docs scope
- independent Opus and Gemini final reviews: approved with no blockers

Closes #82.
Refs #81 and #76.
