### PR TITLE
Make Odoo image dependency scans causal and artifact-bound

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -16,6 +16,7 @@
       "devtools": "bash scripts/smoke-devtools.sh <image-reference>",
       "smokeDbInit": "bash scripts/smoke-db-init.sh <image-reference>",
       "downstreamHelpers": "bash scripts/test-downstream-helpers.sh <image-reference>",
+      "dependencyHealth": "bash scripts/test-image-dependency-health.sh",
       "odooBinWrapper": "bash scripts/test-odoo-bin-wrapper.sh",
       "requirementsOverrides": "bash scripts/test-check-requirements-overrides.sh"
     },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
       resolver_cutoff: ${{ steps.inputs.outputs.resolver_cutoff }}
       scan_configuration_sha256: ${{ steps.inputs.outputs.scan_configuration_sha256 }}
       trivy_db_sha256: ${{ steps.inputs.outputs.trivy_db_sha256 }}
+      trivy_image: ${{ steps.inputs.outputs.trivy_image }}
       trivy_version: ${{ steps.inputs.outputs.trivy_version }}
     steps:
       - uses: actions/checkout@v7
@@ -95,12 +96,32 @@ jobs:
 
       - name: Resolve comparison inputs and scanner database
         id: inputs
+        env:
+          BASELINE_COMMIT: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -euo pipefail
 
           resolver_cutoff="$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:00:00Z')"
           apt_snapshot="$(date -u -d '24 hours ago' '+%Y%m%dT%H0000Z')"
           ubuntu_image='ubuntu:noble@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517'
+          trivy_image="${TRIVY_IMAGE}"
+
+          if [ -n "${BASELINE_COMMIT}" ]; then
+            git fetch --no-tags --depth 1 origin "${BASELINE_COMMIT}"
+            if git cat-file -e "${BASELINE_COMMIT}:scripts/scan-image-dependencies.sh" 2>/dev/null \
+              && ! git diff --quiet "${BASELINE_COMMIT}" HEAD -- \
+                .github/workflows/build.yml \
+                scripts/image-dependency-health.py \
+                scripts/scan-image-dependencies.sh; then
+              trivy_image="$(git show "${BASELINE_COMMIT}:.github/workflows/build.yml" \
+                | sed -n 's/^  TRIVY_IMAGE: //p' \
+                | head -n 1)"
+            fi
+          fi
+          if [[ ! "${trivy_image}" =~ ^aquasec/trivy:[0-9]+\.[0-9]+\.[0-9]+@sha256:[0-9a-f]{64}$ ]]; then
+            echo "Resolved Trivy image is not an approved immutable reference" >&2
+            exit 1
+          fi
 
           postgresql_versions="$(docker run --rm --platform linux/amd64 \
             --env APT_SNAPSHOT="${apt_snapshot}" \
@@ -140,10 +161,10 @@ jobs:
           mkdir -p "${trivy_cache}"
           docker run --rm \
             --volume "${trivy_cache}:/root/.cache/trivy" \
-            "${TRIVY_IMAGE}" image \
+            "${trivy_image}" image \
             --cache-dir /root/.cache/trivy \
             --download-db-only
-          trivy_version="$(docker run --rm "${TRIVY_IMAGE}" --version --format json | jq -er '.Version')"
+          trivy_version="$(docker run --rm "${trivy_image}" --version --format json | jq -er '.Version')"
           trivy_db_sha256="$(cd "${trivy_cache}" \
             && find . -type f -print0 \
               | sort -z \
@@ -160,7 +181,7 @@ jobs:
             --arg python_version "${PYTHON_VERSION}" \
             --arg resolver_cutoff "${resolver_cutoff}" \
             --arg trivy_db_sha256 "${trivy_db_sha256}" \
-            --arg trivy_image "${TRIVY_IMAGE}" \
+            --arg trivy_image "${trivy_image}" \
             --arg trivy_version "${trivy_version}" \
             '{
               apt_snapshot: $apt_snapshot,
@@ -202,6 +223,7 @@ jobs:
             echo "resolver_cutoff=${resolver_cutoff}"
             echo "scan_configuration_sha256=${scan_configuration_sha256}"
             echo "trivy_db_sha256=${trivy_db_sha256}"
+            echo "trivy_image=${trivy_image}"
             echo "trivy_version=${trivy_version}"
           } >>"${GITHUB_OUTPUT}"
 
@@ -533,6 +555,7 @@ jobs:
           SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
           TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
           TRIVY_DB_SHA256: ${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}
+          TRIVY_IMAGE: ${{ needs.resolve_inputs.outputs.trivy_image }}
           TRIVY_VERSION: ${{ needs.resolve_inputs.outputs.trivy_version }}
         run: |
           tooling_root="${GITHUB_WORKSPACE}"
@@ -556,6 +579,7 @@ jobs:
           SCAN_CONFIGURATION_SHA256: ${{ needs.resolve_inputs.outputs.scan_configuration_sha256 }}
           TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
           TRIVY_DB_SHA256: ${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}
+          TRIVY_IMAGE: ${{ needs.resolve_inputs.outputs.trivy_image }}
           TRIVY_VERSION: ${{ needs.resolve_inputs.outputs.trivy_version }}
         run: |
           bash "${BASELINE_ROOT}/scripts/scan-image-dependencies.sh" \
@@ -923,6 +947,7 @@ jobs:
           SCAN_CONFIGURATION_SHA256: ${{ needs.resolve_inputs.outputs.scan_configuration_sha256 }}
           TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
           TRIVY_DB_SHA256: ${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}
+          TRIVY_IMAGE: ${{ needs.resolve_inputs.outputs.trivy_image }}
           TRIVY_VERSION: ${{ needs.resolve_inputs.outputs.trivy_version }}
         run: |
           set -euo pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,7 +306,21 @@ jobs:
           done
 
           comparison_parity="false"
-          if [ "${resolver_parity}" = "true" ] && [ "${scanner_parity}" = "true" ]; then
+          resolver_contract="false"
+          if [ "$(grep -c '^ARG APT_SNAPSHOT$' "${BASELINE_ROOT}/Dockerfile")" -ge 2 ] \
+            && [ "$(grep -c '^ARG POSTGRESQL_CLIENT_VERSION$' "${BASELINE_ROOT}/Dockerfile")" -ge 2 ] \
+            && [ "$(grep -c '^ARG POSTGRESQL_CLIENT_COMMON_VERSION$' "${BASELINE_ROOT}/Dockerfile")" -ge 2 ] \
+            && [ "$(grep -c '^ARG POSTGRESQL_LIBPQ_VERSION$' "${BASELINE_ROOT}/Dockerfile")" -ge 2 ] \
+            && [ "$(grep -c '^ARG RESOLVER_CUTOFF$' "${BASELINE_ROOT}/Dockerfile")" -ge 2 ] \
+            && grep -q 'ubuntu:noble@sha256:' "${BASELINE_ROOT}/Dockerfile" \
+            && grep -Fq "snapshot.ubuntu.com/ubuntu/\${APT_SNAPSHOT}" "${BASELINE_ROOT}/Dockerfile" \
+            && grep -q 'apt-archive.postgresql.org' "${BASELINE_ROOT}/Dockerfile" \
+            && grep -q 'UV_EXCLUDE_NEWER' "${BASELINE_ROOT}/Dockerfile"; then
+            resolver_contract="true"
+          fi
+          if [ "${resolver_parity}" = "true" ] \
+            && [ "${resolver_contract}" = "true" ] \
+            && [ "${scanner_parity}" = "true" ]; then
             comparison_parity="true"
           fi
 
@@ -314,9 +328,11 @@ jobs:
             echo "value=${resolver_parity}"
             echo "scanner_available=${scanner_available}"
             echo "scanner_parity=${scanner_parity}"
+            echo "resolver_contract=${resolver_contract}"
             echo "comparison=${comparison_parity}"
           } >>"${GITHUB_OUTPUT}"
           echo "Native base/head resolver parity: ${resolver_parity}"
+          echo "Baseline resolver contract complete: ${resolver_contract}"
           echo "Trusted baseline scanner available: ${scanner_available}"
           echo "Base/head scanner parity: ${scanner_parity}"
           echo "Causal comparison eligible: ${comparison_parity}"
@@ -332,6 +348,23 @@ jobs:
           set -euo pipefail
           tar -C "${RUNNER_TEMP}" -xzf \
             "${RUNNER_TEMP}/dependency-health-inputs/trivy-cache.tar.gz"
+          actual_db_sha256="$(cd "${RUNNER_TEMP}/trivy-cache" \
+            && find . -type f -print0 \
+              | sort -z \
+              | xargs -0 sha256sum \
+              | sha256sum \
+              | awk '{print $1}')"
+          if [ "${actual_db_sha256}" != "${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}" ]; then
+            echo "Restored Trivy database digest does not match resolved inputs" >&2
+            exit 1
+          fi
+          actual_configuration_sha256="$(sha256sum \
+            "${RUNNER_TEMP}/dependency-health-inputs/comparison-inputs.json" \
+            | awk '{print $1}')"
+          if [ "${actual_configuration_sha256}" != "${{ needs.resolve_inputs.outputs.scan_configuration_sha256 }}" ]; then
+            echo "Restored scan configuration digest does not match resolved inputs" >&2
+            exit 1
+          fi
 
       - name: Resolve persistent verify builder name
         id: verify_builder
@@ -361,7 +394,7 @@ jobs:
           pull: true
           load: true
           platforms: linux/amd64
-          tags: odoo-docker:baseline-${{ matrix.suffix }}
+          tags: odoo-docker:baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
           provenance: false
           sbom: false
           build-args: |
@@ -387,7 +420,7 @@ jobs:
           pull: true
           load: true
           platforms: linux/amd64
-          tags: odoo-docker:verify-${{ matrix.suffix }}
+          tags: odoo-docker:verify-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
           provenance: false
           sbom: false
           build-args: |
@@ -415,7 +448,7 @@ jobs:
           load: true
           no-cache: true
           platforms: linux/amd64
-          tags: odoo-docker:verify-${{ matrix.suffix }}
+          tags: odoo-docker:verify-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
           provenance: false
           sbom: false
           build-args: |
@@ -436,15 +469,15 @@ jobs:
           exit 1
 
       - name: Smoke test verification image
-        run: ${{ matrix.smoke_script }} odoo-docker:verify-${{ matrix.suffix }}
+        run: ${{ matrix.smoke_script }} odoo-docker:verify-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
 
       - name: Smoke test database initialization
         if: matrix.target == 'runtime'
-        run: scripts/smoke-db-init.sh odoo-docker:verify-runtime
+        run: scripts/smoke-db-init.sh odoo-docker:verify-${{ github.run_id }}-${{ github.run_attempt }}-runtime
 
       - name: Validate downstream helper contract
         if: matrix.target == 'runtime'
-        run: scripts/test-downstream-helpers.sh odoo-docker:verify-runtime
+        run: scripts/test-downstream-helpers.sh odoo-docker:verify-${{ github.run_id }}-${{ github.run_attempt }}-runtime
 
       - name: Record verification build provenance
         env:
@@ -507,7 +540,7 @@ jobs:
             tooling_root="${BASELINE_ROOT}"
           fi
           bash "${tooling_root}/scripts/scan-image-dependencies.sh" \
-            "odoo-docker:verify-${{ matrix.suffix }}" \
+            "odoo-docker:verify-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}" \
             "${SOURCE_COMMIT}" \
             "${BASELINE_COMMIT}" \
             "image:${{ matrix.suffix }}:linux/amd64" \
@@ -526,7 +559,7 @@ jobs:
           TRIVY_VERSION: ${{ needs.resolve_inputs.outputs.trivy_version }}
         run: |
           bash "${BASELINE_ROOT}/scripts/scan-image-dependencies.sh" \
-            "odoo-docker:baseline-${{ matrix.suffix }}" \
+            "odoo-docker:baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}" \
             "${BASELINE_COMMIT}" \
             "" \
             "image:${{ matrix.suffix }}:linux/amd64" \
@@ -652,6 +685,23 @@ jobs:
           set -euo pipefail
           tar -C "${RUNNER_TEMP}" -xzf \
             "${RUNNER_TEMP}/dependency-health-inputs/trivy-cache.tar.gz"
+          actual_db_sha256="$(cd "${RUNNER_TEMP}/trivy-cache" \
+            && find . -type f -print0 \
+              | sort -z \
+              | xargs -0 sha256sum \
+              | sha256sum \
+              | awk '{print $1}')"
+          if [ "${actual_db_sha256}" != "${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}" ]; then
+            echo "Restored Trivy database digest does not match resolved inputs" >&2
+            exit 1
+          fi
+          actual_configuration_sha256="$(sha256sum \
+            "${RUNNER_TEMP}/dependency-health-inputs/comparison-inputs.json" \
+            | awk '{print $1}')"
+          if [ "${actual_configuration_sha256}" != "${{ needs.resolve_inputs.outputs.scan_configuration_sha256 }}" ]; then
+            echo "Restored scan configuration digest does not match resolved inputs" >&2
+            exit 1
+          fi
 
       - uses: docker/setup-qemu-action@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -368,9 +368,11 @@ jobs:
       - name: Restore scanner database
         run: |
           set -euo pipefail
-          tar -C "${RUNNER_TEMP}" -xzf \
+          cache_root="${RUNNER_TEMP}/trivy-cache-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.suffix }}"
+          mkdir -p "${cache_root}"
+          tar -C "${cache_root}" --strip-components=1 -xzf \
             "${RUNNER_TEMP}/dependency-health-inputs/trivy-cache.tar.gz"
-          actual_db_sha256="$(cd "${RUNNER_TEMP}/trivy-cache" \
+          actual_db_sha256="$(cd "${cache_root}" \
             && find . -type f -print0 \
               | sort -z \
               | xargs -0 sha256sum \
@@ -553,7 +555,7 @@ jobs:
           SCAN_CONFIGURATION_SHA256: ${{ needs.resolve_inputs.outputs.scan_configuration_sha256 }}
           SCANNER_AVAILABLE: ${{ steps.resolver_parity.outputs.scanner_available || 'false' }}
           SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
-          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
           TRIVY_DB_SHA256: ${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}
           TRIVY_IMAGE: ${{ needs.resolve_inputs.outputs.trivy_image }}
           TRIVY_VERSION: ${{ needs.resolve_inputs.outputs.trivy_version }}
@@ -577,7 +579,7 @@ jobs:
           BASELINE_ROOT: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
           DEPENDENCY_HEALTH_REPOSITORY: ${{ github.repository }}
           SCAN_CONFIGURATION_SHA256: ${{ needs.resolve_inputs.outputs.scan_configuration_sha256 }}
-          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
           TRIVY_DB_SHA256: ${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}
           TRIVY_IMAGE: ${{ needs.resolve_inputs.outputs.trivy_image }}
           TRIVY_VERSION: ${{ needs.resolve_inputs.outputs.trivy_version }}
@@ -707,9 +709,11 @@ jobs:
       - name: Restore scanner database
         run: |
           set -euo pipefail
-          tar -C "${RUNNER_TEMP}" -xzf \
+          cache_root="${RUNNER_TEMP}/trivy-cache-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.suffix }}"
+          mkdir -p "${cache_root}"
+          tar -C "${cache_root}" --strip-components=1 -xzf \
             "${RUNNER_TEMP}/dependency-health-inputs/trivy-cache.tar.gz"
-          actual_db_sha256="$(cd "${RUNNER_TEMP}/trivy-cache" \
+          actual_db_sha256="$(cd "${cache_root}" \
             && find . -type f -print0 \
               | sort -z \
               | xargs -0 sha256sum \
@@ -945,7 +949,7 @@ jobs:
           MANIFEST_DIGEST: ${{ steps.published.outputs.digest }}
           ODOO_SOURCE_REV: ${{ needs.resolve_source.outputs.odoo_source_rev }}
           SCAN_CONFIGURATION_SHA256: ${{ needs.resolve_inputs.outputs.scan_configuration_sha256 }}
-          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
           TRIVY_DB_SHA256: ${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}
           TRIVY_IMAGE: ${{ needs.resolve_inputs.outputs.trivy_image }}
           TRIVY_VERSION: ${{ needs.resolve_inputs.outputs.trivy_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ concurrency:
 env:
   DOCKER_BUILD_SUMMARY: false
   DOCKER_BUILD_RECORD_UPLOAD: false
+  PYTHON_VERSION: 3.13.15
+  TRIVY_IMAGE: aquasec/trivy:0.74.0@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969
 
 jobs:
   dockerfile-lint:
@@ -38,6 +40,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Run Hadolint
         run: |
@@ -66,6 +70,147 @@ jobs:
           fi
           echo "value=${source_revision}" >> "${GITHUB_OUTPUT}"
           echo "Resolved Odoo source revision: ${source_revision}"
+
+  resolve_inputs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    outputs:
+      apt_snapshot: ${{ steps.inputs.outputs.apt_snapshot }}
+      postgresql_client_common_version: ${{ steps.inputs.outputs.postgresql_client_common_version }}
+      postgresql_client_version: ${{ steps.inputs.outputs.postgresql_client_version }}
+      postgresql_libpq_version: ${{ steps.inputs.outputs.postgresql_libpq_version }}
+      resolver_cutoff: ${{ steps.inputs.outputs.resolver_cutoff }}
+      scan_configuration_sha256: ${{ steps.inputs.outputs.scan_configuration_sha256 }}
+      trivy_db_sha256: ${{ steps.inputs.outputs.trivy_db_sha256 }}
+      trivy_version: ${{ steps.inputs.outputs.trivy_version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Validate dependency-health tooling
+        run: scripts/test-image-dependency-health.sh
+
+      - name: Resolve comparison inputs and scanner database
+        id: inputs
+        run: |
+          set -euo pipefail
+
+          resolver_cutoff="$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:00:00Z')"
+          apt_snapshot="$(date -u -d '24 hours ago' '+%Y%m%dT%H0000Z')"
+          ubuntu_image='ubuntu:noble@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517'
+
+          postgresql_versions="$(docker run --rm --platform linux/amd64 \
+            --env APT_SNAPSHOT="${apt_snapshot}" \
+            --volume /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro \
+            "${ubuntu_image}" \
+            bash -euo pipefail -c '
+              snapshot_url="https://snapshot.ubuntu.com/ubuntu/${APT_SNAPSHOT}/"
+              sed -i \
+                -e "s|http:/[/]archive.ubuntu.com/ubuntu/|${snapshot_url}|g" \
+                -e "s|http:/[/]security.ubuntu.com/ubuntu/|${snapshot_url}|g" \
+                /etc/apt/sources.list.d/ubuntu.sources
+              apt-get update >/dev/null
+              apt-get install -y --no-install-recommends curl gnupg >/dev/null
+              curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+                | gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
+              echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt-archive.postgresql.org/pub/repos/apt noble-pgdg-archive main" \
+                >/etc/apt/sources.list.d/pgdg.list
+              apt-get update >/dev/null
+              for package in postgresql-client-17 postgresql-client-common libpq5; do
+                apt-cache madison "${package}" >"/tmp/${package}-versions"
+                IFS="|" read -r _ version _ <"/tmp/${package}-versions"
+                version="$(echo "${version}" | xargs)"
+                echo "${package}=${version}"
+              done
+            ')"
+          postgresql_client_version="$(sed -n 's/^postgresql-client-17=//p' <<<"${postgresql_versions}")"
+          postgresql_client_common_version="$(sed -n 's/^postgresql-client-common=//p' <<<"${postgresql_versions}")"
+          postgresql_libpq_version="$(sed -n 's/^libpq5=//p' <<<"${postgresql_versions}")"
+          if [ -z "${postgresql_client_version}" ] \
+            || [ -z "${postgresql_client_common_version}" ] \
+            || [ -z "${postgresql_libpq_version}" ]; then
+            echo "Failed to resolve exact PostgreSQL package set" >&2
+            exit 1
+          fi
+
+          trivy_cache="${RUNNER_TEMP}/trivy-cache"
+          mkdir -p "${trivy_cache}"
+          docker run --rm \
+            --volume "${trivy_cache}:/root/.cache/trivy" \
+            "${TRIVY_IMAGE}" image \
+            --cache-dir /root/.cache/trivy \
+            --download-db-only
+          trivy_version="$(docker run --rm "${TRIVY_IMAGE}" --version --format json | jq -er '.Version')"
+          trivy_db_sha256="$(cd "${trivy_cache}" \
+            && find . -type f -print0 \
+              | sort -z \
+              | xargs -0 sha256sum \
+              | sha256sum \
+              | awk '{print $1}')"
+
+          mkdir -p "${RUNNER_TEMP}/dependency-health-inputs"
+          jq -cn \
+            --arg apt_snapshot "${apt_snapshot}" \
+            --arg postgresql_client_common_version "${postgresql_client_common_version}" \
+            --arg postgresql_client_version "${postgresql_client_version}" \
+            --arg postgresql_libpq_version "${postgresql_libpq_version}" \
+            --arg python_version "${PYTHON_VERSION}" \
+            --arg resolver_cutoff "${resolver_cutoff}" \
+            --arg trivy_db_sha256 "${trivy_db_sha256}" \
+            --arg trivy_image "${TRIVY_IMAGE}" \
+            --arg trivy_version "${trivy_version}" \
+            '{
+              apt_snapshot: $apt_snapshot,
+              postgresql_packages: {
+                client: $postgresql_client_version,
+                client_common: $postgresql_client_common_version,
+                libpq: $postgresql_libpq_version
+              },
+              python_version: $python_version,
+              resolver_cutoff: $resolver_cutoff,
+              scanner: {
+                image: $trivy_image,
+                version: $trivy_version,
+                databases_sha256: $trivy_db_sha256,
+                scanners: ["vulnerability"],
+                severities: ["LOW", "MEDIUM", "HIGH", "CRITICAL"],
+                ignore_unfixed: true,
+                ignorefile: "/dev/null",
+                skipped_files: [
+                  "/usr/share/java/gettext.jar",
+                  "/usr/share/java/libintl-0.21.jar"
+                ],
+                skip_java_database: true
+              }
+            }' >"${RUNNER_TEMP}/dependency-health-inputs/comparison-inputs.json"
+          scan_configuration_sha256="$(sha256sum \
+            "${RUNNER_TEMP}/dependency-health-inputs/comparison-inputs.json" \
+            | awk '{print $1}')"
+
+          tar -C "${RUNNER_TEMP}" -czf \
+            "${RUNNER_TEMP}/dependency-health-inputs/trivy-cache.tar.gz" \
+            trivy-cache
+
+          {
+            echo "apt_snapshot=${apt_snapshot}"
+            echo "postgresql_client_common_version=${postgresql_client_common_version}"
+            echo "postgresql_client_version=${postgresql_client_version}"
+            echo "postgresql_libpq_version=${postgresql_libpq_version}"
+            echo "resolver_cutoff=${resolver_cutoff}"
+            echo "scan_configuration_sha256=${scan_configuration_sha256}"
+            echo "trivy_db_sha256=${trivy_db_sha256}"
+            echo "trivy_version=${trivy_version}"
+          } >>"${GITHUB_OUTPUT}"
+
+      - name: Upload comparison inputs
+        uses: actions/upload-artifact@v7
+        with:
+          name: dependency-health-inputs
+          path: ${{ runner.temp }}/dependency-health-inputs
+          if-no-files-found: error
 
   check_overrides:
     runs-on: ubuntu-latest
@@ -98,8 +243,8 @@ jobs:
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, x64, chris-testing-build]
-    timeout-minutes: 60
-    needs: [resolve_source, check_overrides]
+    timeout-minutes: 90
+    needs: [resolve_source, resolve_inputs, check_overrides]
     permissions:
       contents: read
     strategy:
@@ -115,6 +260,78 @@ jobs:
             smoke_script: scripts/smoke-devtools.sh
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Materialize exact pull-request baseline
+        if: github.event_name == 'pull_request'
+        env:
+          BASELINE_COMMIT: ${{ github.event.pull_request.base.sha }}
+          BASELINE_ROOT: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${BASELINE_ROOT}"
+          git fetch --no-tags --depth 1 origin "${BASELINE_COMMIT}"
+          git archive "${BASELINE_COMMIT}" | tar -x -C "${BASELINE_ROOT}"
+
+      - name: Detect native resolver and scanner parity
+        id: resolver_parity
+        if: github.event_name == 'pull_request'
+        env:
+          BASELINE_ROOT: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
+        run: |
+          set -euo pipefail
+          resolver_parity="false"
+          if grep -q '^ARG APT_SNAPSHOT$' "${BASELINE_ROOT}/Dockerfile" \
+            && grep -q '^ARG POSTGRESQL_CLIENT_VERSION$' "${BASELINE_ROOT}/Dockerfile" \
+            && grep -q '^ARG POSTGRESQL_CLIENT_COMMON_VERSION$' "${BASELINE_ROOT}/Dockerfile" \
+            && grep -q '^ARG POSTGRESQL_LIBPQ_VERSION$' "${BASELINE_ROOT}/Dockerfile" \
+            && grep -q '^ARG RESOLVER_CUTOFF$' "${BASELINE_ROOT}/Dockerfile"; then
+            resolver_parity="true"
+          fi
+
+          scanner_available="true"
+          scanner_parity="true"
+          for path in \
+            .github/workflows/build.yml \
+            scripts/image-dependency-health.py \
+            scripts/scan-image-dependencies.sh
+          do
+            if [ ! -f "${BASELINE_ROOT}/${path}" ]; then
+              scanner_available="false"
+              scanner_parity="false"
+            elif ! cmp -s "${BASELINE_ROOT}/${path}" "${path}"; then
+              scanner_parity="false"
+            fi
+          done
+
+          comparison_parity="false"
+          if [ "${resolver_parity}" = "true" ] && [ "${scanner_parity}" = "true" ]; then
+            comparison_parity="true"
+          fi
+
+          {
+            echo "value=${resolver_parity}"
+            echo "scanner_available=${scanner_available}"
+            echo "scanner_parity=${scanner_parity}"
+            echo "comparison=${comparison_parity}"
+          } >>"${GITHUB_OUTPUT}"
+          echo "Native base/head resolver parity: ${resolver_parity}"
+          echo "Trusted baseline scanner available: ${scanner_available}"
+          echo "Base/head scanner parity: ${scanner_parity}"
+          echo "Causal comparison eligible: ${comparison_parity}"
+
+      - name: Download comparison inputs
+        uses: actions/download-artifact@v8
+        with:
+          name: dependency-health-inputs
+          path: ${{ runner.temp }}/dependency-health-inputs
+
+      - name: Restore scanner database
+        run: |
+          set -euo pipefail
+          tar -C "${RUNNER_TEMP}" -xzf \
+            "${RUNNER_TEMP}/dependency-health-inputs/trivy-cache.tar.gz"
 
       - name: Resolve persistent verify builder name
         id: verify_builder
@@ -132,6 +349,31 @@ jobs:
 
       - name: Validate odoo-bin wrapper behavior
         run: scripts/test-odoo-bin-wrapper.sh
+
+      - name: Build baseline image
+        if: github.event_name == 'pull_request' && steps.resolver_parity.outputs.comparison == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.setup_buildx_verify.outputs.name }}
+          context: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
+          file: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}/Dockerfile
+          target: ${{ matrix.target }}
+          pull: true
+          load: true
+          platforms: linux/amd64
+          tags: odoo-docker:baseline-${{ matrix.suffix }}
+          provenance: false
+          sbom: false
+          build-args: |
+            ODOO_SOURCE_REF=19.0
+            ODOO_SOURCE_REV=${{ needs.resolve_source.outputs.odoo_source_rev }}
+            APT_REFRESH_EPOCH=${{ github.run_id }}
+            APT_SNAPSHOT=${{ needs.resolve_inputs.outputs.apt_snapshot }}
+            POSTGRESQL_CLIENT_COMMON_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_common_version }}
+            POSTGRESQL_CLIENT_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_version }}
+            POSTGRESQL_LIBPQ_VERSION=${{ needs.resolve_inputs.outputs.postgresql_libpq_version }}
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            RESOLVER_CUTOFF=${{ needs.resolve_inputs.outputs.resolver_cutoff }}
 
       - name: Build verification image (attempt 1)
         id: verify_build_attempt_1
@@ -152,6 +394,12 @@ jobs:
             ODOO_SOURCE_REF=19.0
             ODOO_SOURCE_REV=${{ needs.resolve_source.outputs.odoo_source_rev }}
             APT_REFRESH_EPOCH=${{ github.run_id }}
+            APT_SNAPSHOT=${{ needs.resolve_inputs.outputs.apt_snapshot }}
+            POSTGRESQL_CLIENT_COMMON_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_common_version }}
+            POSTGRESQL_CLIENT_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_version }}
+            POSTGRESQL_LIBPQ_VERSION=${{ needs.resolve_inputs.outputs.postgresql_libpq_version }}
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            RESOLVER_CUTOFF=${{ needs.resolve_inputs.outputs.resolver_cutoff }}
 
       - name: Build verification image (attempt 2, no cache import)
         id: verify_build_attempt_2
@@ -174,6 +422,12 @@ jobs:
             ODOO_SOURCE_REF=19.0
             ODOO_SOURCE_REV=${{ needs.resolve_source.outputs.odoo_source_rev }}
             APT_REFRESH_EPOCH=${{ github.run_id }}
+            APT_SNAPSHOT=${{ needs.resolve_inputs.outputs.apt_snapshot }}
+            POSTGRESQL_CLIENT_COMMON_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_common_version }}
+            POSTGRESQL_CLIENT_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_version }}
+            POSTGRESQL_LIBPQ_VERSION=${{ needs.resolve_inputs.outputs.postgresql_libpq_version }}
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            RESOLVER_CUTOFF=${{ needs.resolve_inputs.outputs.resolver_cutoff }}
 
       - name: Fail verification build after retries
         if: steps.verify_build_attempt_1.outcome == 'failure' && steps.verify_build_attempt_2.outcome == 'failure'
@@ -192,22 +446,132 @@ jobs:
         if: matrix.target == 'runtime'
         run: scripts/test-downstream-helpers.sh odoo-docker:verify-runtime
 
-      - name: Scan verification image
+      - name: Record verification build provenance
+        env:
+          BASELINE_COMMIT: ${{ github.event.pull_request.base.sha || '' }}
+          BASELINE_ROOT: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
+          COMPARISON_PARITY: ${{ steps.resolver_parity.outputs.comparison || 'false' }}
+          RESOLVER_PARITY: ${{ steps.resolver_parity.outputs.value || 'false' }}
+          SCANNER_PARITY: ${{ steps.resolver_parity.outputs.scanner_parity || 'false' }}
+          SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -v "${RUNNER_TEMP}/trivy-cache:/root/.cache" \
-            aquasec/trivy:0.70.0 image \
-            --scanners vulnerability \
-            --ignore-unfixed \
-            --severity HIGH,CRITICAL \
-            --exit-code 1 \
-            odoo-docker:verify-${{ matrix.suffix }}
+          set -euo pipefail
+          evidence_root="${RUNNER_TEMP}/dependency-health-${{ matrix.suffix }}"
+          mkdir -p "${evidence_root}"
+          baseline_dockerfile_sha256=""
+          if [ "${RESOLVER_PARITY}" = "true" ]; then
+            baseline_dockerfile_sha256="$(sha256sum "${BASELINE_ROOT}/Dockerfile" | awk '{print $1}')"
+          fi
+          jq -cn \
+            --slurpfile inputs "${RUNNER_TEMP}/dependency-health-inputs/comparison-inputs.json" \
+            --arg baseline_commit "${BASELINE_COMMIT}" \
+            --arg baseline_dockerfile_sha256 "${baseline_dockerfile_sha256}" \
+            --arg buildx_version "$(docker buildx version)" \
+            --arg comparison_parity "${COMPARISON_PARITY}" \
+            --arg docker_server_version "$(docker version --format '{{.Server.Version}}')" \
+            --arg platform "linux/amd64" \
+            --arg resolver_parity "${RESOLVER_PARITY}" \
+            --arg scanner_parity "${SCANNER_PARITY}" \
+            --arg source_commit "${SOURCE_COMMIT}" \
+            --arg source_dockerfile_sha256 "$(sha256sum Dockerfile | awk '{print $1}')" \
+            --arg target "${{ matrix.target }}" \
+            '{
+              source_commit: $source_commit,
+              baseline_commit: $baseline_commit,
+              target: $target,
+              platform: $platform,
+              source_dockerfile_sha256: $source_dockerfile_sha256,
+              baseline_dockerfile_sha256: $baseline_dockerfile_sha256,
+              buildx_version: $buildx_version,
+              docker_server_version: $docker_server_version,
+              comparison_parity: ($comparison_parity == "true"),
+              resolver_parity: ($resolver_parity == "true"),
+              scanner_parity: ($scanner_parity == "true"),
+              resolved_inputs: $inputs[0]
+            }' >"${evidence_root}/build-provenance.json"
+
+      - name: Scan candidate verification image
+        env:
+          BASELINE_COMMIT: ${{ github.event.pull_request.base.sha || '' }}
+          BASELINE_ROOT: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
+          DEPENDENCY_HEALTH_REPOSITORY: ${{ github.repository }}
+          SCAN_CONFIGURATION_SHA256: ${{ needs.resolve_inputs.outputs.scan_configuration_sha256 }}
+          SCANNER_AVAILABLE: ${{ steps.resolver_parity.outputs.scanner_available || 'false' }}
+          SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+          TRIVY_DB_SHA256: ${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}
+          TRIVY_VERSION: ${{ needs.resolve_inputs.outputs.trivy_version }}
+        run: |
+          tooling_root="${GITHUB_WORKSPACE}"
+          if [ "${SCANNER_AVAILABLE}" = "true" ]; then
+            tooling_root="${BASELINE_ROOT}"
+          fi
+          bash "${tooling_root}/scripts/scan-image-dependencies.sh" \
+            "odoo-docker:verify-${{ matrix.suffix }}" \
+            "${SOURCE_COMMIT}" \
+            "${BASELINE_COMMIT}" \
+            "image:${{ matrix.suffix }}:linux/amd64" \
+            docker \
+            "${RUNNER_TEMP}/dependency-health-${{ matrix.suffix }}/candidate"
+
+      - name: Scan baseline verification image
+        if: github.event_name == 'pull_request' && steps.resolver_parity.outputs.comparison == 'true'
+        env:
+          BASELINE_COMMIT: ${{ github.event.pull_request.base.sha }}
+          BASELINE_ROOT: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
+          DEPENDENCY_HEALTH_REPOSITORY: ${{ github.repository }}
+          SCAN_CONFIGURATION_SHA256: ${{ needs.resolve_inputs.outputs.scan_configuration_sha256 }}
+          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+          TRIVY_DB_SHA256: ${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}
+          TRIVY_VERSION: ${{ needs.resolve_inputs.outputs.trivy_version }}
+        run: |
+          bash "${BASELINE_ROOT}/scripts/scan-image-dependencies.sh" \
+            "odoo-docker:baseline-${{ matrix.suffix }}" \
+            "${BASELINE_COMMIT}" \
+            "" \
+            "image:${{ matrix.suffix }}:linux/amd64" \
+            docker \
+            "${RUNNER_TEMP}/dependency-health-${{ matrix.suffix }}/baseline"
+
+      - name: Evaluate causal dependency regression
+        if: github.event_name == 'pull_request' && steps.resolver_parity.outputs.comparison == 'true'
+        env:
+          BASELINE_ROOT: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
+        run: |
+          python3 "${BASELINE_ROOT}/scripts/image-dependency-health.py" compare \
+            --baseline "${RUNNER_TEMP}/dependency-health-${{ matrix.suffix }}/baseline/snapshot.json" \
+            --candidate "${RUNNER_TEMP}/dependency-health-${{ matrix.suffix }}/candidate/snapshot.json" \
+            --output "${RUNNER_TEMP}/dependency-health-${{ matrix.suffix }}/comparison.json"
+
+      - name: Preserve absolute gate without trusted comparison parity
+        if: github.event_name != 'pull_request' || steps.resolver_parity.outputs.comparison != 'true'
+        env:
+          BASELINE_ROOT: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
+          SCANNER_AVAILABLE: ${{ steps.resolver_parity.outputs.scanner_available || 'false' }}
+        run: |
+          tooling_root="${GITHUB_WORKSPACE}"
+          if [ "${SCANNER_AVAILABLE}" = "true" ]; then
+            tooling_root="${BASELINE_ROOT}"
+          fi
+          python3 "${tooling_root}/scripts/image-dependency-health.py" absolute \
+            --snapshot "${RUNNER_TEMP}/dependency-health-${{ matrix.suffix }}/candidate/snapshot.json" \
+            --output "${RUNNER_TEMP}/dependency-health-${{ matrix.suffix }}/absolute.json"
+
+      - name: Upload verification dependency evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dependency-health-verify-${{ matrix.suffix }}
+          path: ${{ runner.temp }}/dependency-health-${{ matrix.suffix }}
+          if-no-files-found: error
 
       - name: Prune stale persistent verify builder cache
         if: always()
+        env:
+          BASELINE_ROOT: ${{ runner.temp }}/odoo-docker-baseline-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.suffix }}
         run: |
           set -euo pipefail
+          rm -rf "${BASELINE_ROOT}"
           docker buildx prune \
             --builder "${{ steps.setup_buildx_verify.outputs.name }}" \
             --force \
@@ -219,7 +583,7 @@ jobs:
     name: image-verification
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [dockerfile-lint, resolve_source, check_overrides, verify]
+    needs: [dockerfile-lint, resolve_source, resolve_inputs, check_overrides, verify]
     if: always() && github.event_name == 'pull_request'
     permissions:
       contents: read
@@ -230,6 +594,7 @@ jobs:
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           DOCKERFILE_LINT_RESULT: ${{ needs.dockerfile-lint.result }}
           RESOLVE_SOURCE_RESULT: ${{ needs.resolve_source.result }}
+          RESOLVE_INPUTS_RESULT: ${{ needs.resolve_inputs.result }}
           CHECK_OVERRIDES_RESULT: ${{ needs.check_overrides.result }}
           VERIFY_RESULT: ${{ needs.verify.result }}
         run: |
@@ -243,6 +608,7 @@ jobs:
           for result in \
             "${DOCKERFILE_LINT_RESULT}" \
             "${RESOLVE_SOURCE_RESULT}" \
+            "${RESOLVE_INPUTS_RESULT}" \
             "${CHECK_OVERRIDES_RESULT}" \
             "${VERIFY_RESULT}"
           do
@@ -255,7 +621,10 @@ jobs:
   publish:
     runs-on: [self-hosted, linux, x64, chris-testing-publish-cache]
     timeout-minutes: 240
-    needs: [resolve_source, verify]
+    concurrency:
+      group: odoo-docker-publish
+      cancel-in-progress: false
+    needs: [resolve_source, resolve_inputs, verify]
     if: github.event_name != 'pull_request'
     permissions:
       contents: read
@@ -271,6 +640,18 @@ jobs:
             suffix: devtools
     steps:
       - uses: actions/checkout@v7
+
+      - name: Download comparison inputs
+        uses: actions/download-artifact@v8
+        with:
+          name: dependency-health-inputs
+          path: ${{ runner.temp }}/dependency-health-inputs
+
+      - name: Restore scanner database
+        run: |
+          set -euo pipefail
+          tar -C "${RUNNER_TEMP}" -xzf \
+            "${RUNNER_TEMP}/dependency-health-inputs/trivy-cache.tar.gz"
 
       - uses: docker/setup-qemu-action@v4
         with:
@@ -296,7 +677,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build tag set
+      - name: Build candidate and promotion tag sets
         id: tags
         env:
           ODOO_SOURCE_REV: ${{ needs.resolve_source.outputs.odoo_source_rev }}
@@ -304,13 +685,17 @@ jobs:
         run: |
           set -euo pipefail
           source_short_sha="${ODOO_SOURCE_REV::12}"
+          repository_short_sha="${GITHUB_SHA::12}"
           nightly_date="$(date -u +%Y%m%d)"
           image_root="ghcr.io/${GITHUB_REPOSITORY}"
-
-          tags=("${image_root}:sha-${source_short_sha}-${{ matrix.suffix }}")
+          candidate_tag="${image_root}:candidate-${GITHUB_RUN_ID}-${repository_short_sha}-${{ matrix.suffix }}"
+          aliases=(
+            "${image_root}:build-${GITHUB_RUN_ID}-${repository_short_sha}-${{ matrix.suffix }}"
+            "${image_root}:sha-${source_short_sha}-${{ matrix.suffix }}"
+          )
 
           if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
-            tags+=("${image_root}:nightly-${{ matrix.suffix }}" "${image_root}:nightly-${nightly_date}-${{ matrix.suffix }}")
+            aliases+=("${image_root}:nightly-${{ matrix.suffix }}" "${image_root}:nightly-${nightly_date}-${{ matrix.suffix }}")
           fi
 
           publish_stable="false"
@@ -322,12 +707,13 @@ jobs:
           fi
 
           if [ "${publish_stable}" = "true" ]; then
-            tags+=("${image_root}:19.0-${{ matrix.suffix }}")
+            aliases+=("${image_root}:19.0-${{ matrix.suffix }}")
           fi
 
           {
-            echo "value<<EOF"
-            printf '%s\n' "${tags[@]}"
+            echo "candidate=${candidate_tag}"
+            echo "aliases<<EOF"
+            printf '%s\n' "${aliases[@]}"
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
@@ -343,7 +729,7 @@ jobs:
           pull: true
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.tags.outputs.value }}
+          tags: ${{ steps.tags.outputs.candidate }}
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.suffix }}
           cache-to: |
@@ -354,6 +740,12 @@ jobs:
             ODOO_SOURCE_REF=19.0
             ODOO_SOURCE_REV=${{ needs.resolve_source.outputs.odoo_source_rev }}
             APT_REFRESH_EPOCH=${{ github.run_id }}
+            APT_SNAPSHOT=${{ needs.resolve_inputs.outputs.apt_snapshot }}
+            POSTGRESQL_CLIENT_COMMON_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_common_version }}
+            POSTGRESQL_CLIENT_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_version }}
+            POSTGRESQL_LIBPQ_VERSION=${{ needs.resolve_inputs.outputs.postgresql_libpq_version }}
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            RESOLVER_CUTOFF=${{ needs.resolve_inputs.outputs.resolver_cutoff }}
 
       - name: Refresh ghcr login before retry
         if: steps.publish_attempt_1.outcome == 'failure'
@@ -376,7 +768,7 @@ jobs:
           pull: true
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.tags.outputs.value }}
+          tags: ${{ steps.tags.outputs.candidate }}
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.suffix }},mode=max
           provenance: false
           sbom: false
@@ -384,6 +776,12 @@ jobs:
             ODOO_SOURCE_REF=19.0
             ODOO_SOURCE_REV=${{ needs.resolve_source.outputs.odoo_source_rev }}
             APT_REFRESH_EPOCH=${{ github.run_id }}
+            APT_SNAPSHOT=${{ needs.resolve_inputs.outputs.apt_snapshot }}
+            POSTGRESQL_CLIENT_COMMON_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_common_version }}
+            POSTGRESQL_CLIENT_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_version }}
+            POSTGRESQL_LIBPQ_VERSION=${{ needs.resolve_inputs.outputs.postgresql_libpq_version }}
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            RESOLVER_CUTOFF=${{ needs.resolve_inputs.outputs.resolver_cutoff }}
 
       - name: Refresh ghcr login before final retry
         if: steps.publish_attempt_1.outcome == 'failure' && steps.publish_attempt_2.outcome == 'failure'
@@ -405,7 +803,7 @@ jobs:
           pull: true
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.tags.outputs.value }}
+          tags: ${{ steps.tags.outputs.candidate }}
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.suffix }}
           provenance: false
@@ -414,33 +812,184 @@ jobs:
             ODOO_SOURCE_REF=19.0
             ODOO_SOURCE_REV=${{ needs.resolve_source.outputs.odoo_source_rev }}
             APT_REFRESH_EPOCH=${{ github.run_id }}
+            APT_SNAPSHOT=${{ needs.resolve_inputs.outputs.apt_snapshot }}
+            POSTGRESQL_CLIENT_COMMON_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_common_version }}
+            POSTGRESQL_CLIENT_VERSION=${{ needs.resolve_inputs.outputs.postgresql_client_version }}
+            POSTGRESQL_LIBPQ_VERSION=${{ needs.resolve_inputs.outputs.postgresql_libpq_version }}
+            PYTHON_VERSION=${{ env.PYTHON_VERSION }}
+            RESOLVER_CUTOFF=${{ needs.resolve_inputs.outputs.resolver_cutoff }}
 
-      - name: Record published digest
+      - name: Resolve exact published candidate digest
+        id: published
         env:
           DIGEST_ATTEMPT_1: ${{ steps.publish_attempt_1.outputs.digest }}
           DIGEST_ATTEMPT_2: ${{ steps.publish_attempt_2.outputs.digest }}
           DIGEST_ATTEMPT_3: ${{ steps.publish_attempt_3.outputs.digest }}
+          OUTCOME_ATTEMPT_1: ${{ steps.publish_attempt_1.outcome }}
+          OUTCOME_ATTEMPT_2: ${{ steps.publish_attempt_2.outcome }}
+          OUTCOME_ATTEMPT_3: ${{ steps.publish_attempt_3.outcome }}
+          CANDIDATE_IMAGE: ${{ steps.tags.outputs.candidate }}
           SUFFIX: ${{ matrix.suffix }}
         run: |
           set -euo pipefail
 
-          image_digest="${DIGEST_ATTEMPT_1:-}"
-          if [ -z "${image_digest}" ]; then
+          image_digest=""
+          if [ "${OUTCOME_ATTEMPT_1}" = "success" ]; then
+            image_digest="${DIGEST_ATTEMPT_1:-}"
+          elif [ "${OUTCOME_ATTEMPT_2}" = "success" ]; then
             image_digest="${DIGEST_ATTEMPT_2:-}"
-          fi
-          if [ -z "${image_digest}" ]; then
+          elif [ "${OUTCOME_ATTEMPT_3}" = "success" ]; then
             image_digest="${DIGEST_ATTEMPT_3:-}"
           fi
           if [ -z "${image_digest}" ]; then
             echo "Published image digest was not reported by Buildx for ${SUFFIX}" >&2
             exit 1
           fi
+          if [[ ! "${image_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Buildx reported an invalid digest for ${SUFFIX}: ${image_digest}" >&2
+            exit 1
+          fi
+
+          evidence_root="${RUNNER_TEMP}/published-evidence/${SUFFIX}"
+          mkdir -p "${evidence_root}"
+          docker buildx imagetools inspect --raw "${CANDIDATE_IMAGE}" \
+            >"${evidence_root}/manifest.json"
+          registry_digest="sha256:$(sha256sum "${evidence_root}/manifest.json" | awk '{print $1}')"
+          if [ "${registry_digest}" != "${image_digest}" ]; then
+            echo "Registry digest ${registry_digest} does not match Buildx digest ${image_digest}" >&2
+            exit 1
+          fi
+
+          echo "digest=${registry_digest}" >>"${GITHUB_OUTPUT}"
+          echo "evidence_root=${evidence_root}" >>"${GITHUB_OUTPUT}"
+
+      - name: Scan exact published platform digests
+        env:
+          DEPENDENCY_HEALTH_REPOSITORY: ${{ github.repository }}
+          EVIDENCE_ROOT: ${{ steps.published.outputs.evidence_root }}
+          IMAGE_ROOT: ghcr.io/${{ github.repository }}
+          MANIFEST_DIGEST: ${{ steps.published.outputs.digest }}
+          ODOO_SOURCE_REV: ${{ needs.resolve_source.outputs.odoo_source_rev }}
+          SCAN_CONFIGURATION_SHA256: ${{ needs.resolve_inputs.outputs.scan_configuration_sha256 }}
+          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+          TRIVY_DB_SHA256: ${{ needs.resolve_inputs.outputs.trivy_db_sha256 }}
+          TRIVY_VERSION: ${{ needs.resolve_inputs.outputs.trivy_version }}
+        run: |
+          set -euo pipefail
+
+          jq -cn \
+            --slurpfile inputs "${RUNNER_TEMP}/dependency-health-inputs/comparison-inputs.json" \
+            --arg buildx_version "$(docker buildx version)" \
+            --arg docker_server_version "$(docker version --format '{{.Server.Version}}')" \
+            --arg manifest_digest "${MANIFEST_DIGEST}" \
+            --arg odoo_source_revision "${ODOO_SOURCE_REV}" \
+            --arg repository_commit "${GITHUB_SHA}" \
+            --arg source_dockerfile_sha256 "$(sha256sum Dockerfile | awk '{print $1}')" \
+            --arg target "${{ matrix.target }}" \
+            '{
+              repository_commit: $repository_commit,
+              odoo_source_revision: $odoo_source_revision,
+              target: $target,
+              platforms: ["linux/amd64", "linux/arm64"],
+              manifest_digest: $manifest_digest,
+              source_dockerfile_sha256: $source_dockerfile_sha256,
+              buildx_version: $buildx_version,
+              docker_server_version: $docker_server_version,
+              resolved_inputs: $inputs[0]
+            }' >"${EVIDENCE_ROOT}/build-provenance.json"
+
+          mapfile -t platform_rows < <(jq -er '
+            [.manifests[]
+              | select(.platform.os == "linux")
+              | select(.platform.architecture == "amd64" or .platform.architecture == "arm64")
+              | [(.platform.os + "/" + .platform.architecture), .digest]
+              | @tsv]
+            | sort
+            | .[]' "${EVIDENCE_ROOT}/manifest.json")
+          if [ "${#platform_rows[@]}" -ne 2 ]; then
+            echo "Published manifest must contain exactly amd64 and arm64 image manifests" >&2
+            exit 1
+          fi
+
+          platform_snapshot_arguments=()
+          for row in "${platform_rows[@]}"; do
+            IFS=$'\t' read -r platform child_digest <<<"${row}"
+            case "${platform}" in
+              linux/amd64 | linux/arm64) ;;
+              *) echo "Unexpected published platform: ${platform}" >&2; exit 1 ;;
+            esac
+            if [[ ! "${child_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "Invalid child digest for ${platform}: ${child_digest}" >&2
+              exit 1
+            fi
+            platform_name="${platform#linux/}"
+            platform_root="${EVIDENCE_ROOT}/${platform_name}"
+            child_reference="${IMAGE_ROOT}@${child_digest}"
+            scripts/scan-image-dependencies.sh \
+              "${child_reference}" \
+              "${GITHUB_SHA}" \
+              "" \
+              "${child_reference}#${platform}" \
+              remote \
+              "${platform_root}"
+            platform_snapshot_arguments+=(
+              --platform-snapshot "${platform}=${platform_root}/snapshot.json"
+            )
+          done
+
+          python3 scripts/image-dependency-health.py artifact-evidence \
+            --repository "${GITHUB_REPOSITORY}" \
+            --image "${IMAGE_ROOT}" \
+            --parent-digest "${MANIFEST_DIGEST}" \
+            --manifest-json "${EVIDENCE_ROOT}/manifest.json" \
+            --build-provenance "${EVIDENCE_ROOT}/build-provenance.json" \
+            "${platform_snapshot_arguments[@]}" \
+            --output "${EVIDENCE_ROOT}/artifact-evidence.json"
+
+      - name: Promote validated aliases
+        env:
+          ALIASES: ${{ steps.tags.outputs.aliases }}
+          IMAGE_ROOT: ghcr.io/${{ github.repository }}
+          MANIFEST_DIGEST: ${{ steps.published.outputs.digest }}
+        run: |
+          set -euo pipefail
+          alias_arguments=()
+          while IFS= read -r alias; do
+            [ -n "${alias}" ] || continue
+            alias_arguments+=(--tag "${alias}")
+          done <<<"${ALIASES}"
+          if [ "${#alias_arguments[@]}" -eq 0 ]; then
+            echo "No validated aliases were selected for promotion" >&2
+            exit 1
+          fi
+          docker buildx imagetools create \
+            "${alias_arguments[@]}" \
+            "${IMAGE_ROOT}@${MANIFEST_DIGEST}"
+
+          while IFS= read -r alias; do
+            [ -n "${alias}" ] || continue
+            alias_digest="$(docker buildx imagetools inspect "${alias}" \
+              | awk '/^Digest:/ {print $2; exit}')"
+            if [ "${alias_digest}" != "${MANIFEST_DIGEST}" ]; then
+              echo "Alias ${alias} resolved to ${alias_digest}, expected ${MANIFEST_DIGEST}" >&2
+              exit 1
+            fi
+          done <<<"${ALIASES}"
+
+      - name: Record published digest
+        env:
+          EVIDENCE_ROOT: ${{ steps.published.outputs.evidence_root }}
+          IMAGE_DIGEST: ${{ steps.published.outputs.digest }}
+          SUFFIX: ${{ matrix.suffix }}
+        run: |
+          set -euo pipefail
 
           mkdir -p "${RUNNER_TEMP}/published-digests"
           jq -cn \
             --arg suffix "${SUFFIX}" \
-            --arg digest "${image_digest}" \
-            '{suffix: $suffix, digest: $digest}' \
+            --arg digest "${IMAGE_DIGEST}" \
+            --arg evidence_sha256 "$(sha256sum "${EVIDENCE_ROOT}/artifact-evidence.json" | awk '{print $1}')" \
+            '{suffix: $suffix, digest: $digest, absolute_evidence_sha256: $evidence_sha256}' \
             >"${RUNNER_TEMP}/published-digests/${SUFFIX}.json"
 
       - name: Upload published digest
@@ -448,6 +997,13 @@ jobs:
         with:
           name: published-digest-${{ matrix.suffix }}
           path: ${{ runner.temp }}/published-digests/${{ matrix.suffix }}.json
+          if-no-files-found: error
+
+      - name: Upload published absolute evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: published-absolute-evidence-${{ matrix.suffix }}
+          path: ${{ steps.published.outputs.evidence_root }}
           if-no-files-found: error
 
       - name: Prune stale persistent publish builder cache

--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -65,6 +65,7 @@ jobs:
               /^19\.0-(runtime|devtools)$/,
               /^nightly-(runtime|devtools)$/,
               /^nightly-\d{8}-(runtime|devtools)$/,
+              /^buildcache-(runtime|devtools)$/,
             ];
 
             const shouldKeepByTag = (tags) =>
@@ -78,12 +79,16 @@ jobs:
             }
 
             for (const suffix of ["runtime", "devtools"]) {
-              const shaRegex = new RegExp(`^sha-[0-9a-f]+-${suffix}$`);
-              const recentShaVersions = taggedVersions.filter((version) =>
-                version.metadata.container.tags.some((tag) => shaRegex.test(tag)),
-              );
-              for (const version of recentShaVersions.slice(0, keepShaCount)) {
-                keepIds.add(version.id);
+              for (const prefix of ["sha", "build", "candidate"]) {
+                const immutableRegex = prefix === "sha"
+                  ? new RegExp(`^sha-[0-9a-f]+-${suffix}$`)
+                  : new RegExp(`^${prefix}-[0-9]+-[0-9a-f]+-${suffix}$`);
+                const recentVersions = taggedVersions.filter((version) =>
+                  version.metadata.container.tags.some((tag) => immutableRegex.test(tag)),
+                );
+                for (const version of recentVersions.slice(0, keepShaCount)) {
+                  keepIds.add(version.id);
+                }
               }
             }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,17 @@
 ARG ODOO_SOURCE_REPOSITORY=https://github.com/odoo/odoo.git
 ARG ODOO_SOURCE_REF=19.0
 ARG ODOO_SOURCE_REV
-ARG PYTHON_VERSION=3.13
+ARG PYTHON_VERSION=3.13.15
+ARG APT_SNAPSHOT
+ARG POSTGRESQL_CLIENT_VERSION
+ARG POSTGRESQL_CLIENT_COMMON_VERSION
+ARG POSTGRESQL_LIBPQ_VERSION
+ARG RESOLVER_CUTOFF
 
 # Keep the official uv image first so Dependabot tracks it for Docker updates.
 FROM --platform=$TARGETPLATFORM ghcr.io/astral-sh/uv:0.12.3@sha256:2d890623d310b57771ce840f0da5eed5fc6d657da05ffaa45d82797b53fa3abc AS uv-binary
 
-FROM --platform=$BUILDPLATFORM alpine/git:v2.54.0 AS odoo-source
+FROM --platform=$BUILDPLATFORM alpine/git:v2.54.0@sha256:a299a963fbe31628ab481ca42907bcf0691d004f86734c02638abdf513691d42 AS odoo-source
 ARG ODOO_SOURCE_REPOSITORY
 ARG ODOO_SOURCE_REF
 ARG ODOO_SOURCE_REV
@@ -23,7 +28,7 @@ RUN set -eux; \
     git -C odoo checkout --detach FETCH_HEAD; \
     rm -rf odoo/.git
 
-FROM --platform=$BUILDPLATFORM alpine/curl:8.21.0 AS wkhtmltox
+FROM --platform=$BUILDPLATFORM alpine/curl:8.21.0@sha256:f10470711a007af40e9f215b576a725be6f82e030e68cb1a7083782f3bb2cab8 AS wkhtmltox
 ARG TARGETARCH
 ARG WKHTMLTOPDF_VERSION=0.12.6.1-3
 ARG WKHTMLTOPDF_TARGET=jammy
@@ -45,9 +50,14 @@ RUN set -eux; \
       "https://github.com/wkhtmltopdf/packaging/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}.${WKHTMLTOPDF_TARGET}_${package_arch}.deb"; \
     echo "${checksum}  wkhtmltox.deb" | sha1sum -c -
 
-FROM ubuntu:noble AS runtime-system
+FROM ubuntu:noble@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 AS runtime-system
 ARG PYTHON_VERSION
 ARG APT_REFRESH_EPOCH=0
+ARG APT_SNAPSHOT
+ARG POSTGRESQL_CLIENT_VERSION
+ARG POSTGRESQL_CLIENT_COMMON_VERSION
+ARG POSTGRESQL_LIBPQ_VERSION
+ARG RESOLVER_CUTOFF
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -55,16 +65,24 @@ COPY --from=wkhtmltox /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certi
 
 RUN set -eux; \
     sed -i \
-      -e 's|http://archive.ubuntu.com/ubuntu/|https://archive.ubuntu.com/ubuntu/|g' \
-      -e 's|http://security.ubuntu.com/ubuntu/|https://security.ubuntu.com/ubuntu/|g' \
-      -e 's|http://ports.ubuntu.com/ubuntu-ports/|https://ports.ubuntu.com/ubuntu-ports/|g' \
+      -e 's|http:/[/]archive.ubuntu.com/ubuntu/|https://archive.ubuntu.com/ubuntu/|g' \
+      -e 's|http:/[/]security.ubuntu.com/ubuntu/|https://security.ubuntu.com/ubuntu/|g' \
+      -e 's|http:/[/]ports.ubuntu.com/ubuntu-ports/|https://ports.ubuntu.com/ubuntu-ports/|g' \
       /etc/apt/sources.list.d/ubuntu.sources; \
     printf '%s\n' \
       'Acquire::Retries "5";' \
       'Acquire::http::Timeout "30";' \
       'Acquire::https::Timeout "30";' \
       'APT::Update::Error-Mode "any";' \
-      > /etc/apt/apt.conf.d/80odoo-network-hardening
+      > /etc/apt/apt.conf.d/80odoo-network-hardening; \
+    if [ -n "${APT_SNAPSHOT:-}" ]; then \
+      snapshot_url="https://snapshot.ubuntu.com/ubuntu/${APT_SNAPSHOT}/"; \
+      sed -i \
+        -e "s|https://archive.ubuntu.com/ubuntu/|${snapshot_url}|g" \
+        -e "s|https://security.ubuntu.com/ubuntu/|${snapshot_url}|g" \
+        -e "s|https://ports.ubuntu.com/ubuntu-ports/|${snapshot_url}|g" \
+        /etc/apt/sources.list.d/ubuntu.sources; \
+    fi
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
@@ -118,13 +136,22 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
     | gpg --dearmor -o /usr/share/keyrings/postgresql.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt noble-pgdg main" \
+    && echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt-archive.postgresql.org/pub/repos/apt noble-pgdg-archive main" \
       > /etc/apt/sources.list.d/pgdg.list
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-client-17 \
+    && if [ -n "${POSTGRESQL_CLIENT_VERSION:-}" ] \
+      && [ -n "${POSTGRESQL_CLIENT_COMMON_VERSION:-}" ] \
+      && [ -n "${POSTGRESQL_LIBPQ_VERSION:-}" ]; then \
+      apt-get install -y --no-install-recommends \
+        "postgresql-client-17=${POSTGRESQL_CLIENT_VERSION}" \
+        "postgresql-client-common=${POSTGRESQL_CLIENT_COMMON_VERSION}" \
+        "libpq5=${POSTGRESQL_LIBPQ_VERSION}"; \
+    else \
+      apt-get install -y --no-install-recommends postgresql-client-17; \
+    fi \
     && rm -f /etc/apt/sources.list.d/pgdg.list \
     && rm -rf /var/lib/apt/lists/*
 
@@ -136,7 +163,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && rm -f /tmp/wkhtmltox.deb \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install --global rtlcss@4.3.0
+RUN if [ -n "${RESOLVER_CUTOFF:-}" ]; then \
+      npm install --global --before="${RESOLVER_CUTOFF}" rtlcss@4.3.0; \
+    else \
+      npm install --global rtlcss@4.3.0; \
+    fi
 
 RUN if ! id -u ubuntu >/dev/null 2>&1; then useradd --create-home --shell /bin/bash ubuntu; fi
 
@@ -152,6 +183,7 @@ ENV UV_PROJECT_ENVIRONMENT=/venv
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 FROM runtime-system AS runtime-pythondeps
+ARG RESOLVER_CUTOFF
 
 RUN --mount=type=cache,target=/home/ubuntu/.cache/uv,uid=1000,gid=1000,sharing=locked \
     install -d -o ubuntu -g ubuntu /opt/uv/python /venv /home/ubuntu/.cache/uv \
@@ -175,9 +207,10 @@ RUN --mount=type=cache,target=/home/ubuntu/.cache/uv,uid=1000,gid=1000,sharing=l
     && test -z "$(find "${base_site_packages}" -maxdepth 1 -name 'pip-*.dist-info' -print -quit)" \
     && test -z "$(find "${base_scripts}" -maxdepth 1 -name 'pip*' -print -quit)" \
     && env -u VIRTUAL_ENV PYTHONDONTWRITEBYTECODE=1 "${base_python}" -c 'import importlib.util; assert importlib.util.find_spec("pip") is None; assert importlib.util.find_spec("ensurepip") is None' \
+    && if [ -n "${RESOLVER_CUTOFF:-}" ]; then export UV_EXCLUDE_NEWER="${RESOLVER_CUTOFF}"; fi \
     && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python -r /odoo/requirements.txt" \
     && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python -r /odoo/requirements-overrides.txt" \
-    && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python rlpycairo" \
+    && su -s /bin/bash ubuntu -c "uv pip install --python /venv/bin/python rlpycairo==0.4.0" \
     && su -s /bin/bash ubuntu -c "uv pip check --python /venv/bin/python"
 
 FROM runtime-pythondeps AS runtime
@@ -218,6 +251,7 @@ USER ubuntu
 FROM runtime AS runtime-devtools
 USER root
 ARG PLAYWRIGHT_VERSION=1.59.1
+ARG RESOLVER_CUTOFF
 
 RUN chmod +x /usr/local/bin/configure-dev-addon-paths.sh \
     && /usr/local/bin/configure-dev-addon-paths.sh
@@ -250,7 +284,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libxkbcommon0 \
       libxrandr2 \
       npm \
-    && PLAYWRIGHT_BROWSERS_PATH=/ms-playwright npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --no-shell \
+    && if [ -n "${RESOLVER_CUTOFF:-}" ]; then \
+      PLAYWRIGHT_BROWSERS_PATH=/ms-playwright npx --yes --before="${RESOLVER_CUTOFF}" "playwright@${PLAYWRIGHT_VERSION}" install chromium --no-shell; \
+    else \
+      PLAYWRIGHT_BROWSERS_PATH=/ms-playwright npx --yes "playwright@${PLAYWRIGHT_VERSION}" install chromium --no-shell; \
+    fi \
     && chromium_path="$(find /ms-playwright -path '*/chrome-linux*/chrome' -type f | sort | head -n 1)" \
     && test -x "${chromium_path}" \
     && ln -sfn "${chromium_path}" /usr/local/bin/chromium-playwright \

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ those image-owned defaults present.
   has native resolver support and its workflow, scanner, and evaluator match
   the head. The comparison uses the base copies of that tooling. Otherwise,
   verification retains the stricter candidate absolute gate, using base scanner
-  tooling when available.
+  tooling and its pinned scanner image when available. Scanner upgrades are
+  therefore validated by the prior scanner on the upgrade pull request and
+  become active for absolute default-branch health after merge.
 - Default-branch, scheduled, and dispatch runs retain absolute high/critical
   health. Multi-architecture images are pushed first under a unique
   `candidate-<run>-<repository-sha>-*` tag, then the exact registry manifest and

--- a/README.md
+++ b/README.md
@@ -136,12 +136,32 @@ those image-owned defaults present.
 ## CI Release Model
 
 - Every run builds test images first and executes smoke checks.
-- Publish only happens after smoke checks pass.
-- `schedule` (weekly) publishes `nightly-*` tags and immutable `sha-*` tags.
-- `push` to `main` publishes stable `19.0-*` tags and immutable `sha-*` tags.
+- Pull-request builds resolve one Ubuntu snapshot, exact PostgreSQL package set,
+  Python/npm cutoff, scanner image, and Trivy database for the comparison.
+  Exact base and head commits use those same inputs. The merge gate blocks
+  introduced or worsened high/critical findings without blaming a pull request
+  for unchanged inherited findings. Causal comparison runs only when the base
+  has native resolver support and its workflow, scanner, and evaluator match
+  the head. The comparison uses the base copies of that tooling. Otherwise,
+  verification retains the stricter candidate absolute gate, using base scanner
+  tooling when available.
+- Default-branch, scheduled, and dispatch runs retain absolute high/critical
+  health. Multi-architecture images are pushed first under a unique
+  `candidate-<run>-<repository-sha>-*` tag, then the exact registry manifest and
+  its `linux/amd64` and `linux/arm64` child digests are scanned. Stable, nightly,
+  source `sha-*`, and validated `build-*` aliases move only after that evidence
+  passes and each alias is verified against the scanned manifest digest.
+- Trivy skips only `/usr/share/java/gettext.jar` and
+  `/usr/share/java/libintl-0.21.jar`, which are owned by Ubuntu's gettext
+  packages, so comparison scans do not require a separate mutable Java
+  database; the installed gettext packages remain covered by the Ubuntu OS
+  advisory scan.
+- `schedule` (weekly) promotes `nightly-*`, `sha-*`, and `build-*` tags.
+- `push` to `main` promotes stable `19.0-*`, `sha-*`, and `build-*` tags.
 - `pull_request` runs verify-only (no image publishing) and reports one stable
   `image-verification` merge gate after lint, source resolution, override
-  validation, both image builds, smoke tests, and vulnerability scans pass.
+  validation, both image builds when resolver parity is available, smoke tests,
+  and dependency-health evaluation pass.
 - Fork pull requests fail closed before using trusted self-hosted runners. A
   maintainer must recreate an accepted fork change on a branch in this
   repository before it can pass the image-verification merge gate.
@@ -164,9 +184,9 @@ same verification gate.
 This keeps the expensive multi-arch publish path warm on the self-hosted runner
 while still giving us a recoverable remote cache when a builder is recreated.
 
-The GHCR retention workflow keeps stable and nightly tags, preserves the newest
-10 immutable `sha-*` tags per image suffix, and prunes untagged versions older
-than 7 days.
+The GHCR retention workflow keeps stable, nightly, and registry-cache tags,
+preserves the newest 10 `sha-*`, validated `build-*`, and `candidate-*` tags per
+image suffix, and prunes untagged versions older than 7 days.
 
 GHCR retention is repo-local package hygiene. This repo owns the package tags it
 publishes, so the retention workflow may delete only this repo's old package
@@ -193,6 +213,13 @@ The workflow resolves the current `odoo/odoo` `19.0` commit and pins that exact
 revision into the build. This gives repeatable artifacts per run and makes
 scheduled updates explicit.
 
+The Dockerfile pins artifact-affecting base and build images by digest, uses an
+exact uv-managed Python patch release, and accepts workflow-resolved Ubuntu
+snapshot, PostgreSQL package, and package-index cutoff inputs. Trivy snapshots
+record repository/source identity, producer and database revisions, scan scope,
+configuration hash, and platform. Publication evidence additionally records the
+exact manifest-list digest, platform child digests, and snapshot hashes.
+
 `uv` is copied from Astral's official container image and pinned by tag+digest
 in the Dockerfile. A GitHub-native Dependabot config watches that image
 reference and opens update PRs whenever a new `uv` release is available.
@@ -215,6 +242,9 @@ docker build \
 - `bash scripts/test-check-requirements-overrides.sh` checks exact pins,
   explicitly allowed unpinned requirements, non-exact constraints, and removed
   requirements for the override freshness gate.
+- `bash scripts/test-image-dependency-health.sh` checks deterministic Trivy
+  normalization, fail-closed provenance matching, regression policy, target
+  advisory handling, and multi-architecture artifact binding.
 - `scripts/test-odoo-bin-wrapper.sh` checks wrapper argument handling without a
   container build.
 - `scripts/smoke-runtime.sh <image-reference>` checks the runtime image helper

--- a/scripts/image-dependency-health.py
+++ b/scripts/image-dependency-health.py
@@ -207,9 +207,15 @@ def build_snapshot(trivy_payload: Any, provenance_payload: Any) -> dict[str, Any
     provenance = validate_provenance(provenance_payload)
     if not isinstance(trivy_payload, dict):
         raise ContractError("Trivy report must be an object")
+    metadata = trivy_payload.get("Metadata")
+    operating_system = metadata.get("OS") if isinstance(metadata, dict) else None
+    if not isinstance(operating_system, dict) or not operating_system.get("Family"):
+        raise ContractError("Trivy report must identify the scanned operating system")
     results = trivy_payload.get("Results", [])
     if not isinstance(results, list):
         raise ContractError("Trivy Results must be an array")
+    if not any(isinstance(result, dict) and result.get("Class") == "os-pkgs" for result in results):
+        raise ContractError("Trivy report must contain operating-system package coverage")
     aggregated: dict[tuple[str, str, str, str], dict[str, Any]] = {}
     for result in results:
         if not isinstance(result, dict):
@@ -424,14 +430,11 @@ def manifest_platforms(payload: Any) -> dict[str, str]:
             continue
         os_name = platform.get("os")
         architecture = platform.get("architecture")
-        variant = platform.get("variant")
         if os_name != "linux" or not isinstance(architecture, str):
             continue
         if architecture not in {"amd64", "arm64"}:
             continue
         key = f"{os_name}/{architecture}"
-        if isinstance(variant, str) and variant:
-            key += f"/{variant}"
         if not DIGEST_PATTERN.fullmatch(digest):
             raise ContractError(f"manifest has invalid digest for {key}: {digest}")
         if key in platforms:

--- a/scripts/image-dependency-health.py
+++ b/scripts/image-dependency-health.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+SEVERITY_RANK = {"low": 1, "moderate": 2, "high": 3, "critical": 4}
+BLOCKING_SEVERITIES = {"high", "critical"}
+DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+ADVISORY_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9._:+-]*$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+NON_COMPARISON_PROVENANCE_FIELDS = {"source_commit", "baseline_commit"}
+
+
+class ContractError(ValueError):
+    pass
+
+
+def read_json(path: str) -> Any:
+    try:
+        return json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise ContractError(f"cannot read valid JSON from {path}: {error}") from error
+
+
+def write_json(path: str, payload: Any) -> None:
+    encoded = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if path == "-":
+        sys.stdout.write(encoded)
+        return
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(encoded)
+
+
+def file_sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def normalize_advisory(value: Any) -> str:
+    advisory = str(value).strip().upper()
+    if not ADVISORY_PATTERN.fullmatch(advisory):
+        raise ContractError(f"invalid advisory identifier: {value!r}")
+    return advisory
+
+
+def normalize_severity(value: Any) -> str:
+    severity = str(value).strip().lower()
+    if severity == "medium":
+        severity = "moderate"
+    if severity not in SEVERITY_RANK:
+        raise ContractError(f"unsupported vulnerability severity: {value!r}")
+    return severity
+
+
+def normalize_ecosystem(value: Any) -> str:
+    ecosystem = re.sub(r"[^a-z0-9._+-]+", "-", str(value).strip().lower()).strip("-")
+    if not ecosystem:
+        raise ContractError("Trivy result is missing a package ecosystem")
+    return ecosystem
+
+
+def normalize_manifest_path(result: dict[str, Any], ecosystem: str) -> str:
+    if str(result.get("Class") or "").strip().lower() == "os-pkgs":
+        return f"os/{ecosystem}"
+    target = str(result.get("Target") or ecosystem).strip().lstrip("/")
+    normalized = re.sub(r"[^A-Za-z0-9._/+-]+", "-", target).strip("-./")
+    if not normalized:
+        raise ContractError("Trivy result has no stable manifest path")
+    return normalized
+
+
+def require_string(payload: dict[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ContractError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def validate_provenance(payload: Any) -> dict[str, str]:
+    if not isinstance(payload, dict):
+        raise ContractError("provenance must be an object")
+    expected_fields = {
+        "repository",
+        "source_commit",
+        "baseline_commit",
+        "producer",
+        "producer_version",
+        "advisory_source",
+        "advisory_revision",
+        "scan_scope",
+        "scan_configuration_sha256",
+    }
+    if set(payload) != expected_fields:
+        missing = sorted(expected_fields - set(payload))
+        extra = sorted(set(payload) - expected_fields)
+        raise ContractError(f"invalid provenance fields; missing={missing}, extra={extra}")
+    normalized = {
+        field: require_string(payload, field)
+        for field in expected_fields
+        if field != "baseline_commit"
+    }
+    baseline_commit = payload.get("baseline_commit")
+    if not isinstance(baseline_commit, str):
+        raise ContractError("baseline_commit must be a string")
+    normalized["baseline_commit"] = baseline_commit.strip()
+    if not COMMIT_PATTERN.fullmatch(normalized["source_commit"]):
+        raise ContractError("source_commit must be a lowercase 40-character Git commit")
+    if normalized["baseline_commit"] and not COMMIT_PATTERN.fullmatch(
+        normalized["baseline_commit"]
+    ):
+        raise ContractError("baseline_commit must be empty or a lowercase 40-character Git commit")
+    if not SHA256_PATTERN.fullmatch(normalized["scan_configuration_sha256"]):
+        raise ContractError("scan_configuration_sha256 must be a lowercase SHA-256")
+    return normalized
+
+
+def normalize_snapshot(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+        raise ContractError("dependency snapshot must use schema_version 1")
+    provenance = validate_provenance(payload.get("provenance"))
+    generated_at = require_string(payload, "generated_at")
+    try:
+        parsed_generated_at = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ContractError("generated_at must be an ISO-8601 timestamp") from error
+    if parsed_generated_at.utcoffset() != timezone.utc.utcoffset(parsed_generated_at):
+        raise ContractError("generated_at must use UTC")
+    findings_payload = payload.get("findings")
+    if not isinstance(findings_payload, list):
+        raise ContractError("findings must be an array")
+    findings: list[dict[str, Any]] = []
+    identities: set[tuple[str, str, str, str]] = set()
+    for raw_finding in findings_payload:
+        if not isinstance(raw_finding, dict):
+            raise ContractError("each finding must be an object")
+        advisory_id = normalize_advisory(raw_finding.get("advisory_id"))
+        aliases_payload = raw_finding.get("aliases", [])
+        if not isinstance(aliases_payload, list):
+            raise ContractError("finding aliases must be an array")
+        aliases = sorted({normalize_advisory(alias) for alias in aliases_payload})
+        if advisory_id in aliases:
+            raise ContractError("finding aliases cannot repeat advisory_id")
+        ecosystem = require_string(raw_finding, "ecosystem").lower()
+        package = require_string(raw_finding, "package")
+        manifest_path = require_string(raw_finding, "manifest_path")
+        severity = normalize_severity(raw_finding.get("severity"))
+        versions_payload = raw_finding.get("versions")
+        if not isinstance(versions_payload, list) or not versions_payload:
+            raise ContractError("finding versions must be a non-empty array")
+        versions = sorted({str(version).strip() for version in versions_payload if str(version).strip()})
+        if not versions:
+            raise ContractError("finding versions cannot contain only empty values")
+        occurrence_count = raw_finding.get("occurrence_count", 1)
+        if type(occurrence_count) is not int or occurrence_count < 1:
+            raise ContractError("finding occurrence_count must be a positive integer")
+        identity = (advisory_id, ecosystem, package, manifest_path)
+        if identity in identities:
+            raise ContractError(f"duplicate finding identity: {identity}")
+        identities.add(identity)
+        findings.append(
+            {
+                "advisory_id": advisory_id,
+                "aliases": aliases,
+                "ecosystem": ecosystem,
+                "package": package,
+                "versions": versions,
+                "occurrence_count": occurrence_count,
+                "manifest_path": manifest_path,
+                "severity": severity,
+            }
+        )
+    findings.sort(key=finding_identity)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "provenance": provenance,
+        "generated_at": parsed_generated_at.astimezone(timezone.utc).isoformat().replace(
+            "+00:00", "Z"
+        ),
+        "findings": findings,
+    }
+
+
+def finding_identity(finding: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        finding["advisory_id"],
+        finding["ecosystem"],
+        finding["package"],
+        finding["manifest_path"],
+    )
+
+
+def build_snapshot(trivy_payload: Any, provenance_payload: Any) -> dict[str, Any]:
+    provenance = validate_provenance(provenance_payload)
+    if not isinstance(trivy_payload, dict):
+        raise ContractError("Trivy report must be an object")
+    results = trivy_payload.get("Results", [])
+    if not isinstance(results, list):
+        raise ContractError("Trivy Results must be an array")
+    aggregated: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    for result in results:
+        if not isinstance(result, dict):
+            raise ContractError("Trivy result must be an object")
+        vulnerabilities = result.get("Vulnerabilities") or []
+        if not isinstance(vulnerabilities, list):
+            raise ContractError("Trivy Vulnerabilities must be an array")
+        ecosystem = normalize_ecosystem(result.get("Type") or result.get("Class") or "unknown")
+        target = normalize_manifest_path(result, ecosystem)
+        for vulnerability in vulnerabilities:
+            if not isinstance(vulnerability, dict):
+                raise ContractError("Trivy vulnerability must be an object")
+            advisory_id = normalize_advisory(vulnerability.get("VulnerabilityID"))
+            package = str(vulnerability.get("PkgName") or "").strip()
+            installed_version = str(vulnerability.get("InstalledVersion") or "").strip()
+            if not package or not installed_version:
+                raise ContractError(f"Trivy finding {advisory_id} lacks package or installed version")
+            severity = normalize_severity(vulnerability.get("Severity"))
+            identity = (advisory_id, ecosystem, package, target)
+            existing = aggregated.get(identity)
+            if existing is None:
+                aggregated[identity] = {
+                    "advisory_id": advisory_id,
+                    "aliases": [],
+                    "ecosystem": ecosystem,
+                    "package": package,
+                    "versions": {installed_version},
+                    "occurrence_count": 1,
+                    "manifest_path": target,
+                    "severity": severity,
+                }
+                continue
+            existing["versions"].add(installed_version)
+            existing["occurrence_count"] += 1
+            if SEVERITY_RANK[severity] > SEVERITY_RANK[existing["severity"]]:
+                existing["severity"] = severity
+    findings = []
+    for finding in aggregated.values():
+        finding["versions"] = sorted(finding["versions"])
+        findings.append(finding)
+    generated_at = str(trivy_payload.get("CreatedAt") or "").strip()
+    if not generated_at:
+        generated_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return normalize_snapshot(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "provenance": provenance,
+            "generated_at": generated_at,
+            "findings": findings,
+        }
+    )
+
+
+def require_compatible_provenance(
+    baseline: dict[str, Any], candidate: dict[str, Any]
+) -> None:
+    baseline_provenance = baseline["provenance"]
+    candidate_provenance = candidate["provenance"]
+    mismatched = []
+    for field in sorted(set(baseline_provenance) - NON_COMPARISON_PROVENANCE_FIELDS):
+        if baseline_provenance[field] != candidate_provenance[field]:
+            mismatched.append(field)
+    if candidate_provenance["baseline_commit"] != baseline_provenance["source_commit"]:
+        mismatched.append("candidate_baseline_commit")
+    if mismatched:
+        raise ContractError(
+            "dependency snapshots have incompatible provenance fields: " + ", ".join(mismatched)
+        )
+
+
+def finding_worsened(baseline: dict[str, Any], candidate: dict[str, Any]) -> bool:
+    return any(
+        (
+            SEVERITY_RANK[candidate["severity"]] > SEVERITY_RANK[baseline["severity"]],
+            len(candidate["versions"]) > len(baseline["versions"]),
+            candidate["occurrence_count"] > baseline["occurrence_count"],
+        )
+    )
+
+
+def advisory_component(findings: list[dict[str, Any]], advisory_id: str) -> set[str]:
+    component = {normalize_advisory(advisory_id)}
+    while True:
+        expanded = set(component)
+        for finding in findings:
+            finding_ids = {finding["advisory_id"], *finding["aliases"]}
+            if finding_ids & component:
+                expanded.update(finding_ids)
+        if expanded == component:
+            return component
+        component = expanded
+
+
+def compare_snapshots(
+    baseline: dict[str, Any], candidate: dict[str, Any], target_advisories: list[str]
+) -> dict[str, Any]:
+    require_compatible_provenance(baseline, candidate)
+    baseline_findings = {finding_identity(finding): finding for finding in baseline["findings"]}
+    candidate_findings = {finding_identity(finding): finding for finding in candidate["findings"]}
+    introduced = []
+    worsened = []
+    resolved = []
+    unchanged = []
+    for identity in sorted(set(baseline_findings) | set(candidate_findings)):
+        baseline_finding = baseline_findings.get(identity)
+        candidate_finding = candidate_findings.get(identity)
+        if baseline_finding is None:
+            if candidate_finding is None:
+                raise AssertionError("comparison identity has no finding")
+            introduced.append(candidate_finding)
+        elif candidate_finding is None:
+            resolved.append(baseline_finding)
+        elif finding_worsened(baseline_finding, candidate_finding):
+            worsened.append({"baseline": baseline_finding, "candidate": candidate_finding})
+        else:
+            unchanged.append({"baseline": baseline_finding, "candidate": candidate_finding})
+
+    reason_codes: set[str] = set()
+    if any(finding["severity"] in BLOCKING_SEVERITIES for finding in introduced):
+        reason_codes.add("introduced_high_or_critical")
+    if any(
+        finding["candidate"]["severity"] in BLOCKING_SEVERITIES for finding in worsened
+    ):
+        reason_codes.add("worsened_to_high_or_critical")
+
+    target_evaluations = []
+    for raw_advisory in sorted(set(target_advisories)):
+        advisory_id = normalize_advisory(raw_advisory)
+        equivalent = advisory_component(baseline["findings"], advisory_id)
+        baseline_matches = [
+            finding
+            for finding in baseline["findings"]
+            if {finding["advisory_id"], *finding["aliases"]} & equivalent
+        ]
+        candidate_matches = [
+            finding
+            for finding in candidate["findings"]
+            if {finding["advisory_id"], *finding["aliases"]} & equivalent
+        ]
+        if not baseline_matches:
+            status = "missing_from_baseline"
+            reason_codes.add("target_advisory_missing_from_baseline")
+        elif candidate_matches:
+            status = "unresolved"
+            reason_codes.add("target_advisory_unresolved")
+        else:
+            status = "resolved"
+        target_evaluations.append(
+            {
+                "advisory_id": advisory_id,
+                "baseline_matches": len(baseline_matches),
+                "candidate_matches": len(candidate_matches),
+                "status": status,
+            }
+        )
+
+    status = "fail" if reason_codes else "pass"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "comparison": {
+            "schema_version": SCHEMA_VERSION,
+            "baseline_provenance": baseline["provenance"],
+            "candidate_provenance": candidate["provenance"],
+            "introduced": introduced,
+            "worsened": worsened,
+            "resolved": resolved,
+            "unchanged": unchanged,
+        },
+        "policy": {
+            "schema_version": SCHEMA_VERSION,
+            "mode": "no_high_or_critical_regressions",
+            "target_advisory_ids": sorted(set(target_advisories)),
+        },
+        "policy_evaluation": {
+            "status": status,
+            "reason_codes": sorted(reason_codes),
+            "target_advisories": target_evaluations,
+            "summary": f"dependency health regression policy {status}ed",
+        },
+    }
+
+
+def absolute_evaluation(snapshot: dict[str, Any]) -> dict[str, Any]:
+    blocking = [
+        finding for finding in snapshot["findings"] if finding["severity"] in BLOCKING_SEVERITIES
+    ]
+    status = "fail" if blocking else "pass"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "snapshot_provenance": snapshot["provenance"],
+        "generated_at": snapshot["generated_at"],
+        "status": status,
+        "finding_count": len(snapshot["findings"]),
+        "blocking_findings": blocking,
+        "summary": f"dependency health absolute policy {status}ed",
+    }
+
+
+def manifest_platforms(payload: Any) -> dict[str, str]:
+    if not isinstance(payload, dict):
+        raise ContractError("manifest index must be an object")
+    manifests = payload.get("manifests")
+    if not isinstance(manifests, list):
+        raise ContractError("manifest index does not contain manifests")
+    platforms: dict[str, str] = {}
+    for manifest in manifests:
+        if not isinstance(manifest, dict):
+            continue
+        platform = manifest.get("platform")
+        digest = manifest.get("digest")
+        if not isinstance(platform, dict) or not isinstance(digest, str):
+            continue
+        os_name = platform.get("os")
+        architecture = platform.get("architecture")
+        variant = platform.get("variant")
+        if os_name != "linux" or not isinstance(architecture, str):
+            continue
+        if architecture not in {"amd64", "arm64"}:
+            continue
+        key = f"{os_name}/{architecture}"
+        if isinstance(variant, str) and variant:
+            key += f"/{variant}"
+        if not DIGEST_PATTERN.fullmatch(digest):
+            raise ContractError(f"manifest has invalid digest for {key}: {digest}")
+        if key in platforms:
+            raise ContractError(f"manifest has duplicate platform: {key}")
+        platforms[key] = digest
+    return platforms
+
+
+def build_artifact_evidence(args: argparse.Namespace) -> dict[str, Any]:
+    if not DIGEST_PATTERN.fullmatch(args.parent_digest):
+        raise ContractError("parent digest must be sha256:<64 lowercase hex characters>")
+    manifest = read_json(args.manifest_json)
+    manifest_sha256 = file_sha256(args.manifest_json)
+    if args.parent_digest != f"sha256:{manifest_sha256}":
+        raise ContractError("parent digest does not match the exact manifest index bytes")
+    platforms = manifest_platforms(manifest)
+    expected_platforms = {"linux/amd64", "linux/arm64"}
+    if set(platforms) != expected_platforms:
+        raise ContractError(
+            f"published manifest platforms must be exactly {sorted(expected_platforms)}; "
+            f"found {sorted(platforms)}"
+        )
+    snapshots: dict[str, dict[str, Any]] = {}
+    for assignment in args.platform_snapshot:
+        if "=" not in assignment:
+            raise ContractError("platform snapshot must use PLATFORM=PATH")
+        platform, path = assignment.split("=", 1)
+        if platform in snapshots:
+            raise ContractError(f"duplicate platform snapshot: {platform}")
+        snapshot = normalize_snapshot(read_json(path))
+        child_digest = platforms.get(platform)
+        if child_digest is None:
+            raise ContractError(f"snapshot platform is not present in manifest: {platform}")
+        scope = snapshot["provenance"]["scan_scope"]
+        if child_digest not in scope or platform not in scope:
+            raise ContractError(
+                f"snapshot scope does not bind {platform} to child digest {child_digest}: {scope}"
+            )
+        snapshots[platform] = {"path": path, "snapshot": snapshot}
+    if set(snapshots) != expected_platforms:
+        raise ContractError("artifact evidence requires amd64 and arm64 snapshots")
+    platform_evidence = []
+    status = "pass"
+    for platform in sorted(expected_platforms):
+        snapshot_entry = snapshots[platform]
+        evaluation = absolute_evaluation(snapshot_entry["snapshot"])
+        if evaluation["status"] != "pass":
+            status = "fail"
+        platform_evidence.append(
+            {
+                "platform": platform,
+                "digest": platforms[platform],
+                "snapshot_sha256": file_sha256(snapshot_entry["path"]),
+                "absolute_evaluation": evaluation,
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repository": args.repository,
+        "image": args.image,
+        "parent_digest": args.parent_digest,
+        "manifest_sha256": manifest_sha256,
+        "build_provenance_sha256": file_sha256(args.build_provenance),
+        "platforms": platform_evidence,
+        "status": status,
+    }
+
+
+def command_snapshot(args: argparse.Namespace) -> int:
+    snapshot = build_snapshot(read_json(args.trivy_json), read_json(args.provenance))
+    write_json(args.output, snapshot)
+    return 0
+
+
+def command_compare(args: argparse.Namespace) -> int:
+    baseline = normalize_snapshot(read_json(args.baseline))
+    candidate = normalize_snapshot(read_json(args.candidate))
+    evaluation = compare_snapshots(baseline, candidate, args.target_advisory)
+    write_json(args.output, evaluation)
+    return 0 if evaluation["policy_evaluation"]["status"] == "pass" else 1
+
+
+def command_absolute(args: argparse.Namespace) -> int:
+    snapshot = normalize_snapshot(read_json(args.snapshot))
+    evaluation = absolute_evaluation(snapshot)
+    write_json(args.output, evaluation)
+    return 0 if evaluation["status"] == "pass" else 1
+
+
+def command_artifact_evidence(args: argparse.Namespace) -> int:
+    evidence = build_artifact_evidence(args)
+    write_json(args.output, evidence)
+    return 0 if evidence["status"] == "pass" else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Create and evaluate Odoo image dependency health evidence")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    snapshot_parser = subparsers.add_parser("snapshot", help="Normalize one Trivy JSON report")
+    snapshot_parser.add_argument("--trivy-json", required=True)
+    snapshot_parser.add_argument("--provenance", required=True)
+    snapshot_parser.add_argument("--output", required=True)
+    snapshot_parser.set_defaults(handler=command_snapshot)
+
+    compare_parser = subparsers.add_parser("compare", help="Evaluate a causal base/head comparison")
+    compare_parser.add_argument("--baseline", required=True)
+    compare_parser.add_argument("--candidate", required=True)
+    compare_parser.add_argument("--target-advisory", action="append", default=[])
+    compare_parser.add_argument("--output", required=True)
+    compare_parser.set_defaults(handler=command_compare)
+
+    absolute_parser = subparsers.add_parser("absolute", help="Evaluate one absolute snapshot")
+    absolute_parser.add_argument("--snapshot", required=True)
+    absolute_parser.add_argument("--output", required=True)
+    absolute_parser.set_defaults(handler=command_absolute)
+
+    evidence_parser = subparsers.add_parser(
+        "artifact-evidence", help="Bind absolute platform scans to one manifest-list digest"
+    )
+    evidence_parser.add_argument("--repository", required=True)
+    evidence_parser.add_argument("--image", required=True)
+    evidence_parser.add_argument("--parent-digest", required=True)
+    evidence_parser.add_argument("--manifest-json", required=True)
+    evidence_parser.add_argument("--build-provenance", required=True)
+    evidence_parser.add_argument("--platform-snapshot", action="append", required=True)
+    evidence_parser.add_argument("--output", required=True)
+    evidence_parser.set_defaults(handler=command_artifact_evidence)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.handler(args)
+    except ContractError as error:
+        print(f"dependency health contract error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scan-image-dependencies.sh
+++ b/scripts/scan-image-dependencies.sh
@@ -20,6 +20,16 @@ output_directory="$6"
 : "${SCAN_CONFIGURATION_SHA256:?SCAN_CONFIGURATION_SHA256 is required}"
 : "${DEPENDENCY_HEALTH_REPOSITORY:?DEPENDENCY_HEALTH_REPOSITORY is required}"
 
+expected_trivy_image='aquasec/trivy:0.74.0@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969'
+if [[ "${TRIVY_IMAGE}" != "${expected_trivy_image}" ]]; then
+  echo "TRIVY_IMAGE must use the repository-approved digest pin" >&2
+  exit 64
+fi
+if [[ "${TRIVY_VERSION}" != "0.74.0" ]]; then
+  echo "TRIVY_VERSION must match the repository-approved scanner" >&2
+  exit 64
+fi
+
 case "${image_source}" in
 docker | remote) ;;
 *)

--- a/scripts/scan-image-dependencies.sh
+++ b/scripts/scan-image-dependencies.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 6 ]]; then
+  echo "Usage: scan-image-dependencies.sh <image> <source-commit> <baseline-commit> <scan-scope> <image-source> <output-directory>" >&2
+  exit 64
+fi
+
+image_reference="$1"
+source_commit="$2"
+baseline_commit="$3"
+scan_scope="$4"
+image_source="$5"
+output_directory="$6"
+
+: "${TRIVY_IMAGE:?TRIVY_IMAGE is required}"
+: "${TRIVY_CACHE_DIR:?TRIVY_CACHE_DIR is required}"
+: "${TRIVY_VERSION:?TRIVY_VERSION is required}"
+: "${TRIVY_DB_SHA256:?TRIVY_DB_SHA256 is required}"
+: "${SCAN_CONFIGURATION_SHA256:?SCAN_CONFIGURATION_SHA256 is required}"
+: "${DEPENDENCY_HEALTH_REPOSITORY:?DEPENDENCY_HEALTH_REPOSITORY is required}"
+
+case "${image_source}" in
+docker | remote) ;;
+*)
+  echo "image source must be docker or remote" >&2
+  exit 64
+  ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mkdir -p "${output_directory}"
+output_directory="$(cd "${output_directory}" && pwd)"
+cache_directory="$(cd "${TRIVY_CACHE_DIR}" && pwd)"
+
+docker_arguments=(
+  run
+  --rm
+  --workdir /tmp
+  --tmpfs /root/.cache/trivy
+  --volume "${cache_directory}/db:/root/.cache/trivy/db:ro"
+  --volume "${output_directory}:/output"
+)
+if [[ "${image_source}" == "docker" ]]; then
+  docker_arguments+=(--volume /var/run/docker.sock:/var/run/docker.sock)
+elif [[ -f "${HOME}/.docker/config.json" ]]; then
+  docker_arguments+=(--volume "${HOME}/.docker/config.json:/root/.docker/config.json:ro")
+fi
+
+docker "${docker_arguments[@]}" "${TRIVY_IMAGE}" image \
+  --cache-dir /root/.cache/trivy \
+  --image-src "${image_source}" \
+  --ignorefile /dev/null \
+  --ignore-unfixed \
+  --scanners vulnerability \
+  --severity LOW,MEDIUM,HIGH,CRITICAL \
+  --skip-files /usr/share/java/gettext.jar \
+  --skip-files /usr/share/java/libintl-0.21.jar \
+  --skip-db-update \
+  --skip-java-db-update \
+  --skip-version-check \
+  --format json \
+  --output /output/trivy.json \
+  "${image_reference}"
+
+jq -cn \
+  --arg repository "${DEPENDENCY_HEALTH_REPOSITORY}" \
+  --arg source_commit "${source_commit}" \
+  --arg baseline_commit "${baseline_commit}" \
+  --arg producer_version "${TRIVY_VERSION}" \
+  --arg advisory_revision "${TRIVY_DB_SHA256}" \
+  --arg scan_scope "${scan_scope}" \
+  --arg scan_configuration_sha256 "${SCAN_CONFIGURATION_SHA256}" \
+  '{
+    repository: $repository,
+    source_commit: $source_commit,
+    baseline_commit: $baseline_commit,
+    producer: "trivy",
+    producer_version: $producer_version,
+    advisory_source: "trivy-db",
+    advisory_revision: $advisory_revision,
+    scan_scope: $scan_scope,
+    scan_configuration_sha256: $scan_configuration_sha256
+  }' >"${output_directory}/provenance.json"
+
+python3 "${repo_root}/scripts/image-dependency-health.py" snapshot \
+  --trivy-json "${output_directory}/trivy.json" \
+  --provenance "${output_directory}/provenance.json" \
+  --output "${output_directory}/snapshot.json"

--- a/scripts/test-image-dependency-health.sh
+++ b/scripts/test-image-dependency-health.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'rm -rf "${test_root}"' EXIT
+
+tool="${repo_root}/scripts/image-dependency-health.py"
+scan_tool="${repo_root}/scripts/scan-image-dependencies.sh"
+workflow="${repo_root}/.github/workflows/build.yml"
+baseline_commit="1111111111111111111111111111111111111111"
+candidate_commit="2222222222222222222222222222222222222222"
+configuration_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+grep -F -- '--skip-files /usr/share/java/gettext.jar' "${scan_tool}" >/dev/null
+grep -F -- '--skip-files /usr/share/java/libintl-0.21.jar' "${scan_tool}" >/dev/null
+if grep -F -- '/usr/share/java/*.jar' "${scan_tool}" >/dev/null; then
+  echo "scanner must not skip unrelated Java archives" >&2
+  exit 1
+fi
+grep -F -- 'group: odoo-docker-publish' "${workflow}" >/dev/null
+grep -F -- '.github/workflows/build.yml' "${workflow}" >/dev/null
+grep -F -- "bash \"\${BASELINE_ROOT}/scripts/scan-image-dependencies.sh\"" "${workflow}" >/dev/null
+grep -F -- "python3 \"\${BASELINE_ROOT}/scripts/image-dependency-health.py\" compare" "${workflow}" >/dev/null
+
+write_provenance() {
+  local path="$1"
+  local source_commit="$2"
+  local asserted_baseline="$3"
+  local scope="${4:-image:runtime:linux/amd64}"
+  cat >"${path}" <<EOF
+{
+  "repository": "cbusillo/odoo-docker",
+  "source_commit": "${source_commit}",
+  "baseline_commit": "${asserted_baseline}",
+  "producer": "trivy",
+  "producer_version": "0.70.0",
+  "advisory_source": "trivy-db",
+  "advisory_revision": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "scan_scope": "${scope}",
+  "scan_configuration_sha256": "${configuration_sha}"
+}
+EOF
+}
+
+write_report() {
+  local path="$1"
+  local vulnerability_id="${2:-}"
+  local severity="${3:-HIGH}"
+  local version="${4:-1.0}"
+  local target="${5:-candidate-image (ubuntu 24.04)}"
+  if [[ -z "${vulnerability_id}" ]]; then
+    cat >"${path}" <<'EOF'
+{"CreatedAt":"2026-08-20T00:00:00Z","Results":[]}
+EOF
+    return
+  fi
+  cat >"${path}" <<EOF
+{
+  "CreatedAt": "2026-08-20T00:00:00Z",
+  "Results": [{
+    "Target": "${target}",
+    "Class": "os-pkgs",
+    "Type": "ubuntu",
+    "Vulnerabilities": [{
+      "VulnerabilityID": "${vulnerability_id}",
+      "PkgName": "example-package",
+      "InstalledVersion": "${version}",
+      "Severity": "${severity}"
+    }]
+  }]
+}
+EOF
+}
+
+write_provenance "${test_root}/baseline-provenance.json" "${baseline_commit}" ""
+write_provenance "${test_root}/candidate-provenance.json" "${candidate_commit}" "${baseline_commit}"
+write_report "${test_root}/baseline-trivy.json" "CVE-2026-1000" "HIGH" "1.0" \
+  "baseline-image (ubuntu 24.04)"
+write_report "${test_root}/candidate-trivy.json" "CVE-2026-1000" "HIGH" "1.0" \
+  "candidate-image (ubuntu 24.04)"
+
+python3 "${tool}" snapshot \
+  --trivy-json "${test_root}/baseline-trivy.json" \
+  --provenance "${test_root}/baseline-provenance.json" \
+  --output "${test_root}/baseline.json"
+python3 "${tool}" snapshot \
+  --trivy-json "${test_root}/candidate-trivy.json" \
+  --provenance "${test_root}/candidate-provenance.json" \
+  --output "${test_root}/candidate.json"
+python3 "${tool}" compare \
+  --baseline "${test_root}/baseline.json" \
+  --candidate "${test_root}/candidate.json" \
+  --output "${test_root}/comparison.json"
+jq -e '.policy_evaluation.status == "pass" and (.comparison.unchanged | length) == 1' \
+  "${test_root}/comparison.json" >/dev/null
+
+if python3 "${tool}" compare \
+  --baseline "${test_root}/baseline.json" \
+  --candidate "${test_root}/candidate.json" \
+  --target-advisory CVE-2026-1000 \
+  --output "${test_root}/unresolved-target.json"; then
+  echo "unresolved target advisory unexpectedly passed" >&2
+  exit 1
+fi
+jq -e '.policy_evaluation.reason_codes == ["target_advisory_unresolved"]' \
+  "${test_root}/unresolved-target.json" >/dev/null
+
+write_report "${test_root}/candidate-trivy.json" "CVE-2026-2000"
+python3 "${tool}" snapshot \
+  --trivy-json "${test_root}/candidate-trivy.json" \
+  --provenance "${test_root}/candidate-provenance.json" \
+  --output "${test_root}/candidate.json"
+if python3 "${tool}" compare \
+  --baseline "${test_root}/baseline.json" \
+  --candidate "${test_root}/candidate.json" \
+  --output "${test_root}/introduced.json"; then
+  echo "introduced high finding unexpectedly passed" >&2
+  exit 1
+fi
+jq -e '.policy_evaluation.reason_codes == ["introduced_high_or_critical"]' \
+  "${test_root}/introduced.json" >/dev/null
+
+write_report "${test_root}/candidate-trivy.json" "CVE-2026-1000" "CRITICAL" "2.0"
+python3 "${tool}" snapshot \
+  --trivy-json "${test_root}/candidate-trivy.json" \
+  --provenance "${test_root}/candidate-provenance.json" \
+  --output "${test_root}/candidate.json"
+if python3 "${tool}" compare \
+  --baseline "${test_root}/baseline.json" \
+  --candidate "${test_root}/candidate.json" \
+  --output "${test_root}/worsened.json"; then
+  echo "worsened high finding unexpectedly passed" >&2
+  exit 1
+fi
+jq -e '.policy_evaluation.reason_codes == ["worsened_to_high_or_critical"]' \
+  "${test_root}/worsened.json" >/dev/null
+
+write_report "${test_root}/candidate-trivy.json"
+python3 "${tool}" snapshot \
+  --trivy-json "${test_root}/candidate-trivy.json" \
+  --provenance "${test_root}/candidate-provenance.json" \
+  --output "${test_root}/candidate.json"
+if python3 "${tool}" compare \
+  --baseline "${test_root}/baseline.json" \
+  --candidate "${test_root}/candidate.json" \
+  --target-advisory CVE-2026-4040 \
+  --output "${test_root}/missing-target.json"; then
+  echo "missing target advisory unexpectedly passed" >&2
+  exit 1
+fi
+jq -e '.policy_evaluation.reason_codes == ["target_advisory_missing_from_baseline"]' \
+  "${test_root}/missing-target.json" >/dev/null
+
+jq '.provenance.scan_configuration_sha256 = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"' \
+  "${test_root}/candidate.json" >"${test_root}/mismatch.json"
+set +e
+python3 "${tool}" compare \
+  --baseline "${test_root}/baseline.json" \
+  --candidate "${test_root}/mismatch.json" \
+  --output "${test_root}/mismatch-output.json" >/dev/null 2>"${test_root}/mismatch-error.txt"
+mismatch_status=$?
+set -e
+[[ "${mismatch_status}" -eq 2 ]]
+grep -q 'scan_configuration_sha256' "${test_root}/mismatch-error.txt"
+
+amd64_digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+arm64_digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+cat >"${test_root}/manifest.json" <<EOF
+{
+  "schemaVersion": 2,
+  "manifests": [
+    {"digest": "${amd64_digest}", "platform": {"os": "linux", "architecture": "amd64"}},
+    {"digest": "${arm64_digest}", "platform": {"os": "linux", "architecture": "arm64"}}
+  ]
+}
+EOF
+parent_digest="sha256:$(sha256sum "${test_root}/manifest.json" | awk '{print $1}')"
+cat >"${test_root}/build-provenance.json" <<'EOF'
+{"builder":"test","platforms":["linux/amd64","linux/arm64"]}
+EOF
+write_provenance "${test_root}/amd64-provenance.json" "${candidate_commit}" "" \
+  "ghcr.io/cbusillo/odoo-docker@${amd64_digest}#linux/amd64"
+write_provenance "${test_root}/arm64-provenance.json" "${candidate_commit}" "" \
+  "ghcr.io/cbusillo/odoo-docker@${arm64_digest}#linux/arm64"
+write_report "${test_root}/clean.json"
+for platform in amd64 arm64; do
+  python3 "${tool}" snapshot \
+    --trivy-json "${test_root}/clean.json" \
+    --provenance "${test_root}/${platform}-provenance.json" \
+    --output "${test_root}/${platform}.json"
+done
+python3 "${tool}" artifact-evidence \
+  --repository cbusillo/odoo-docker \
+  --image ghcr.io/cbusillo/odoo-docker \
+  --parent-digest "${parent_digest}" \
+  --manifest-json "${test_root}/manifest.json" \
+  --build-provenance "${test_root}/build-provenance.json" \
+  --platform-snapshot "linux/amd64=${test_root}/amd64.json" \
+  --platform-snapshot "linux/arm64=${test_root}/arm64.json" \
+  --output "${test_root}/artifact-evidence.json"
+jq -e '.status == "pass" and (.platforms | length) == 2' \
+  "${test_root}/artifact-evidence.json" >/dev/null
+
+echo "image dependency health checks passed"

--- a/scripts/test-image-dependency-health.sh
+++ b/scripts/test-image-dependency-health.sh
@@ -51,13 +51,14 @@ write_report() {
   local target="${5:-candidate-image (ubuntu 24.04)}"
   if [[ -z "${vulnerability_id}" ]]; then
     cat >"${path}" <<'EOF'
-{"CreatedAt":"2026-08-20T00:00:00Z","Results":[]}
+{"CreatedAt":"2026-08-20T00:00:00Z","Metadata":{"OS":{"Family":"ubuntu","Name":"24.04"}},"Results":[{"Target":"candidate-image (ubuntu 24.04)","Class":"os-pkgs","Type":"ubuntu","Vulnerabilities":[]}]}
 EOF
     return
   fi
   cat >"${path}" <<EOF
 {
   "CreatedAt": "2026-08-20T00:00:00Z",
+  "Metadata": {"OS": {"Family": "ubuntu", "Name": "24.04"}},
   "Results": [{
     "Target": "${target}",
     "Class": "os-pkgs",
@@ -75,6 +76,17 @@ EOF
 
 write_provenance "${test_root}/baseline-provenance.json" "${baseline_commit}" ""
 write_provenance "${test_root}/candidate-provenance.json" "${candidate_commit}" "${baseline_commit}"
+
+cat >"${test_root}/empty-trivy.json" <<'EOF'
+{"Metadata":{"OS":{"Family":"ubuntu","Name":"24.04"}},"Results":[]}
+EOF
+if python3 "${tool}" snapshot \
+  --trivy-json "${test_root}/empty-trivy.json" \
+  --provenance "${test_root}/candidate-provenance.json" \
+  --output "${test_root}/empty-snapshot.json"; then
+  echo "empty scanner coverage unexpectedly passed" >&2
+  exit 1
+fi
 write_report "${test_root}/baseline-trivy.json" "CVE-2026-1000" "HIGH" "1.0" \
   "baseline-image (ubuntu 24.04)"
 write_report "${test_root}/candidate-trivy.json" "CVE-2026-1000" "HIGH" "1.0" \


### PR DESCRIPTION
## Summary

- resolve mutable Ubuntu, PostgreSQL, Python/npm, Odoo source, Trivy image, and Trivy database inputs once per dependency-health run
- compare pull-request base and head images only when native resolver and trusted scanner parity make the comparison causal; otherwise retain the stricter absolute gate
- scan the exact published amd64/arm64 child digests and bind absolute evidence to the exact multi-architecture manifest before promoting aliases
- retain causal scan artifacts and unique publication tags while preserving operator-managed Dependabot updates

## Validation

- `bash scripts/test-image-dependency-health.sh`
- `bash scripts/test-check-requirements-overrides.sh`
- `bash scripts/test-odoo-bin-wrapper.sh`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/build.yml .github/workflows/ghcr-retention.yml`
- `shellcheck scripts/scan-image-dependencies.sh scripts/test-image-dependency-health.sh`
- `docker run --rm -v "$PWD:/work:ro" -w /work hadolint/hadolint:v2.14.0 hadolint Dockerfile`
- exact snapshot/toolchain runtime and devtools image builds
- runtime/devtools smoke checks, database initialization smoke, and downstream helper tests
- pinned Trivy 0.74.0 absolute runtime scan: pass, 8 findings, 0 blocking high/critical findings
- PyCharm changed-files inspection: clean
- PyCharm whole-project inspection: 31 pre-existing findings outside this change

Refs cbusillo/launchplane#1936
Refs cbusillo/launchplane#1931
